### PR TITLE
fix: clique panic

### DIFF
--- a/api/validator.go
+++ b/api/validator.go
@@ -116,6 +116,13 @@ func Ecrecover(header *types.Header) ([]byte, error) {
 		return nil, errors.New("unable to recover signature")
 	}
 	signature := header.Extra[start:]
+
+	// Set these to nil or clique.SealHash will panic.
+	header.WithdrawalsHash = nil
+	header.BlobGasUsed = nil
+	header.ExcessBlobGas = nil
+	header.ParentBeaconRoot = nil
+
 	pubkey, err := crypto.Ecrecover(clique.SealHash(header).Bytes(), signature)
 	if err != nil {
 		return nil, err

--- a/api/validator.go
+++ b/api/validator.go
@@ -111,18 +111,19 @@ func Signers(n network.Network) (map[string]*Validator, error) {
 
 // Ecrecover recovers the block signer given the block header.
 func Ecrecover(header *types.Header) ([]byte, error) {
+	// These values will cause clique.SealHash to panic.
+	if header.WithdrawalsHash != nil ||
+		header.BlobGasUsed != nil ||
+		header.ExcessBlobGas != nil ||
+		header.ParentBeaconRoot != nil {
+		return nil, errors.New("unable to encode clique header")
+	}
+
 	start := len(header.Extra) - crypto.SignatureLength
 	if start < 0 || start > len(header.Extra) {
 		return nil, errors.New("unable to recover signature")
 	}
 	signature := header.Extra[start:]
-
-	// Set these to nil or clique.SealHash will panic.
-	header.WithdrawalsHash = nil
-	header.BlobGasUsed = nil
-	header.ExcessBlobGas = nil
-	header.ParentBeaconRoot = nil
-
 	pubkey, err := crypto.Ecrecover(clique.SealHash(header).Bytes(), signature)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

`clique.SealHash` panics if the header has some values. Ignore unset these values, since there will be no chains fetched regardless.

## Jira / Linear Tickets

- closes #25 
- closes #24 

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [x] 👀
```yaml
  rpc:
    - name: "Binance"
      url: "https://bsc-rpc.publicnode.com"
      label: "publicnode.com"
```
- [ ] Deployed Dev
