### PR TITLE
fix(provider): prevent heimdall span ID collapse on API errors

### DIFF
--- a/api/json.go
+++ b/api/json.go
@@ -2,9 +2,27 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
+
+// HTTPError represents an HTTP response with a non-2xx status code.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("HTTP %d %s: %s", e.StatusCode, e.Status, e.Body)
+	}
+	return fmt.Sprintf("HTTP %d %s", e.StatusCode, e.Status)
+}
+
+const maxBodyPreview = 256
 
 // GetJSON fetches JSON data from the specified URL and decodes it into the
 // target variable.
@@ -15,5 +33,15 @@ func GetJSON(url string, target any) error {
 		return err
 	}
 	defer r.Body.Close()
+
+	if r.StatusCode < 200 || r.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodyPreview))
+		return &HTTPError{
+			StatusCode: r.StatusCode,
+			Status:     r.Status,
+			Body:       string(body),
+		}
+	}
+
 	return json.NewDecoder(r.Body).Decode(target)
 }

--- a/api/json.go
+++ b/api/json.go
@@ -22,8 +22,6 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d %s", e.StatusCode, e.Status)
 }
 
-const maxBodyPreview = 256
-
 // GetJSON fetches JSON data from the specified URL and decodes it into the
 // target variable.
 func GetJSON(url string, target any) error {
@@ -35,7 +33,7 @@ func GetJSON(url string, target any) error {
 	defer r.Body.Close()
 
 	if r.StatusCode < 200 || r.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodyPreview))
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 256))
 		return &HTTPError{
 			StatusCode: r.StatusCode,
 			Status:     r.Status,

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetJSON_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name": "test", "value": 42}`))
+	}))
+	defer server.Close()
+
+	var result struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	err := GetJSON(server.URL, &result)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if result.Name != "test" {
+		t.Errorf("expected name 'test', got '%s'", result.Name)
+	}
+	if result.Value != 42 {
+		t.Errorf("expected value 42, got %d", result.Value)
+	}
+}
+
+func TestGetJSON_HTTPError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantBody   string
+	}{
+		{
+			name:       "500 Internal Server Error",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"code":13,"message":"span not found"}`,
+			wantBody:   `{"code":13,"message":"span not found"}`,
+		},
+		{
+			name:       "404 Not Found",
+			statusCode: http.StatusNotFound,
+			body:       "not found",
+			wantBody:   "not found",
+		},
+		{
+			name:       "503 Service Unavailable with empty body",
+			statusCode: http.StatusServiceUnavailable,
+			body:       "",
+			wantBody:   "",
+		},
+		{
+			name:       "400 Bad Request",
+			statusCode: http.StatusBadRequest,
+			body:       "invalid request",
+			wantBody:   "invalid request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			var result struct{}
+			err := GetJSON(server.URL, &result)
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var httpErr *HTTPError
+			if !errors.As(err, &httpErr) {
+				t.Fatalf("expected HTTPError, got %T: %v", err, err)
+			}
+
+			if httpErr.StatusCode != tt.statusCode {
+				t.Errorf("expected status code %d, got %d", tt.statusCode, httpErr.StatusCode)
+			}
+
+			if httpErr.Body != tt.wantBody {
+				t.Errorf("expected body %q, got %q", tt.wantBody, httpErr.Body)
+			}
+		})
+	}
+}
+
+func TestGetJSON_NetworkError(t *testing.T) {
+	// Use an invalid URL to simulate a network error
+	var result struct{}
+	err := GetJSON("http://localhost:1", &result)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Should not be an HTTPError since the connection failed
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		t.Errorf("expected non-HTTPError, got HTTPError: %v", httpErr)
+	}
+}
+
+func TestHTTPError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *HTTPError
+		want string
+	}{
+		{
+			name: "with body",
+			err: &HTTPError{
+				StatusCode: 500,
+				Status:     "500 Internal Server Error",
+				Body:       `{"error":"something failed"}`,
+			},
+			want: `HTTP 500 500 Internal Server Error: {"error":"something failed"}`,
+		},
+		{
+			name: "without body",
+			err: &HTTPError{
+				StatusCode: 503,
+				Status:     "503 Service Unavailable",
+				Body:       "",
+			},
+			want: "HTTP 503 503 Service Unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/config.yml
+++ b/config.yml
@@ -364,6 +364,13 @@
     ## @env PANOPTICHAIN_PROVIDERS_HEIMDALL_0_INTERVAL - string - optional - default: runner.interval
     ## The polling interval for the `heimdall` provider.
     ##
+    ## @param max_span_lag - integer - optional - default: 10
+    ## @env PANOPTICHAIN_PROVIDERS_HEIMDALL_0_MAX_SPAN_LAG - integer - optional - default: 10
+    ## Maximum number of spans to walk sequentially when catching up. If the
+    ## current span falls behind the latest span by more than this value, the
+    ## provider jumps directly to the latest span instead of walking one at a
+    ## time. This prevents long catch-up periods after transient API failures.
+    ##
     ## @param version - integer - optional - default: 1
     ## @env PANOPTICHAIN_PROVIDERS_HEIMDALL_0_VERSION - integer - optional - default: 1
     ## The Heimdall version.
@@ -374,6 +381,7 @@
   #     heimdall_url: "https://heimdall-api.polygon.technology"
   #     label: "polygon.technology"
   #     interval: 5s
+  #     max_span_lag: 10
   #     version: 1
   #
   #   - name: "Polygon Amoy"
@@ -381,6 +389,7 @@
   #     heimdall_url: "https://heimdall-api-amoy.polygon.technology"
   #     label: "polygon.technology"
   #     interval: 5s
+  #     max_span_lag: 10
   #     version: 1
 
   ## @param sensor_network - list of objects - optional

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 )
 
 const DefaultBlockLookBack uint64 = 1000
+const DefaultMaxSpanLag uint64 = 10
 
 // Runner configures the execution interval of the job system.
 type Runner struct {
@@ -128,6 +129,7 @@ type HeimdallEndpoint struct {
 	HeimdallURL   string         `mapstructure:"heimdall_url" validate:"url,required"`
 	Label         string         `mapstructure:"label" validate:"required"`
 	Interval      *time.Duration `mapstructure:"interval"`
+	MaxSpanLag    *uint64        `mapstructure:"max_span_lag"`
 }
 
 // SensorNetwork configures the sensor network provider. This fetches data from

--- a/observer/grafana.go
+++ b/observer/grafana.go
@@ -63,6 +63,15 @@ func (o *GrafanaObserver) Notify(ctx context.Context, m Message) {
 			continue
 		}
 
+		if len(frame.Data.Values) < 2 {
+			log.Warn().Msg("Invalid frame: expected at least 2 value arrays")
+			continue
+		}
+		if len(frame.Data.Values[0]) == 0 || len(frame.Data.Values[1]) == 0 {
+			log.Warn().Msg("Invalid frame: empty value arrays")
+			continue
+		}
+
 		ms := int64(frame.Data.Values[0][len(frame.Data.Values[0])-1])
 		timestamp := time.UnixMilli(ms)
 

--- a/provider/exchange_rates.go
+++ b/provider/exchange_rates.go
@@ -2,14 +2,13 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
 
+	"github.com/0xPolygon/panoptichain/api"
 	"github.com/0xPolygon/panoptichain/config"
 	"github.com/0xPolygon/panoptichain/observer"
 	"github.com/0xPolygon/panoptichain/observer/topics"
@@ -57,17 +56,10 @@ func (e *ExchangeRatesProvider) RefreshState(ctx context.Context) error {
 
 func (e *ExchangeRatesProvider) fetchRates(base string, quotes []string) {
 	url := e.coinbaseURL + base
-	r, err := http.Get(url)
-	if err != nil {
-		e.logger.Error().Err(err).Str("url", url).Send()
-		return
-	}
-	defer r.Body.Close()
 
 	var body CoinbaseExchangeRates
-	err = json.NewDecoder(r.Body).Decode(&body)
-	if err != nil {
-		e.logger.Error().Err(err).Msg("Failed to get exchange rates")
+	if err := api.GetJSON(url, &body); err != nil {
+		e.logger.Error().Err(err).Str("url", url).Msg("Failed to fetch exchange rates")
 		return
 	}
 

--- a/provider/grafana.go
+++ b/provider/grafana.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -46,17 +47,20 @@ func (g *GrafanaProvider) RefreshState(context.Context) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("HTTP %d %s: %s", resp.StatusCode, resp.Status, string(body))
+	}
 
 	var gr observer.GrafanaResponse
-	if err := json.Unmarshal(body, &gr); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
 		return err
 	}
 	g.response = &gr

--- a/provider/heimdall.go
+++ b/provider/heimdall.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
@@ -20,6 +21,10 @@ import (
 	"github.com/0xPolygon/panoptichain/observer/topics"
 )
 
+// ErrInvalidSpan is returned when a span has zero ID with zero blocks,
+// indicating a malformed API response.
+var ErrInvalidSpan = errors.New("invalid span: zero ID with zero blocks")
+
 type HeimdallProvider struct {
 	tendermintURL string
 	heimdallURL   string
@@ -28,6 +33,7 @@ type HeimdallProvider struct {
 	bus           *observer.EventBus
 	interval      time.Duration
 	logger        zerolog.Logger
+	maxSpanLag    uint64
 
 	blockNumber         uint64
 	prevBlockNumber     uint64
@@ -49,6 +55,11 @@ type HeimdallProvider struct {
 }
 
 func NewHeimdallProvider(n network.Network, eb *observer.EventBus, cfg config.HeimdallEndpoint) *HeimdallProvider {
+	maxSpanLag := config.DefaultMaxSpanLag
+	if cfg.MaxSpanLag != nil {
+		maxSpanLag = *cfg.MaxSpanLag
+	}
+
 	return &HeimdallProvider{
 		tendermintURL:       cfg.TendermintURL,
 		heimdallURL:         cfg.HeimdallURL,
@@ -58,6 +69,7 @@ func NewHeimdallProvider(n network.Network, eb *observer.EventBus, cfg config.He
 		blockBuffer:         blockbuffer.NewBlockBuffer(128),
 		interval:            GetInterval(cfg.Interval),
 		logger:              NewLogger(n, cfg.Label),
+		maxSpanLag:          maxSpanLag,
 		checkpointProposers: orderedmap.New[string, struct{}](),
 		refreshStateTime:    new(time.Duration),
 		spans:               &observer.HeimdallSpans{},
@@ -422,6 +434,21 @@ func (h *HeimdallProvider) refreshSpan() error {
 		return nil
 	}
 
+	// Check if lag exceeds maximum threshold
+	lag := latest.ID - h.spans.Curr.ID
+	if lag > h.maxSpanLag {
+		h.logger.Warn().
+			Uint64("current_span_id", h.spans.Curr.ID).
+			Uint64("latest_span_id", latest.ID).
+			Uint64("lag", lag).
+			Uint64("max_span_lag", h.maxSpanLag).
+			Msg("Span lag exceeds maximum, jumping to latest")
+
+		h.spans.Prev = h.spans.Curr
+		h.spans.Curr = latest
+		return nil
+	}
+
 	// Fetch next span sequentially to ensure overlap detection works
 	next := h.spans.Curr.ID + 1
 	span, err := h.getSpan(next)
@@ -456,7 +483,15 @@ func (h *HeimdallProvider) fetchSpan(spanID string) (*observer.HeimdallSpan, err
 		return nil, err
 	}
 
-	return &v2.Span, nil
+	span := &v2.Span
+	if span.ID == 0 && span.StartBlock == 0 && span.EndBlock == 0 {
+		h.logger.Error().
+			Str("requested_span", spanID).
+			Msg("Received invalid zero-value span from API")
+		return nil, ErrInvalidSpan
+	}
+
+	return span, nil
 }
 
 func (h *HeimdallProvider) refreshValidatorSet() error {

--- a/provider/heimdall_test.go
+++ b/provider/heimdall_test.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/0xPolygon/panoptichain/config"
 	"github.com/0xPolygon/panoptichain/observer"
 )
 
@@ -37,6 +39,17 @@ func newProvider(serverURL string, curr *observer.HeimdallSpan) *HeimdallProvide
 		heimdallURL: serverURL,
 		spans:       &observer.HeimdallSpans{Curr: curr},
 		logger:      NewLogger(nil, "test"),
+		maxSpanLag:  config.DefaultMaxSpanLag,
+	}
+}
+
+// newProviderWithMaxLag creates a HeimdallProvider with custom maxSpanLag.
+func newProviderWithMaxLag(serverURL string, curr *observer.HeimdallSpan, maxLag uint64) *HeimdallProvider {
+	return &HeimdallProvider{
+		heimdallURL: serverURL,
+		spans:       &observer.HeimdallSpans{Curr: curr},
+		logger:      NewLogger(nil, "test"),
+		maxSpanLag:  maxLag,
 	}
 }
 
@@ -192,5 +205,119 @@ func TestRefreshSpan_GapFillsOneAtATime(t *testing.T) {
 	}
 	if h.spans.Curr != prevCurr {
 		t.Error("fourth call: expected no change when already at latest span")
+	}
+}
+
+func TestFetchSpan_RejectsZeroValueSpan(t *testing.T) {
+	// Server returns a zero-value span (simulating error envelope decoding to zero struct)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(observer.HeimdallSpanV2{
+			Span: observer.HeimdallSpan{ID: 0, StartBlock: 0, EndBlock: 0},
+		})
+	}))
+	defer server.Close()
+
+	h := newProvider(server.URL, nil)
+	_, err := h.fetchSpan("latest")
+
+	if err == nil {
+		t.Fatal("expected error for zero-value span, got nil")
+	}
+
+	if !errors.Is(err, ErrInvalidSpan) {
+		t.Errorf("expected ErrInvalidSpan, got: %v", err)
+	}
+}
+
+func TestFetchSpan_AcceptsValidSpanZero(t *testing.T) {
+	// Span 0 is valid on mainnet; it has StartBlock=0 but EndBlock > 0
+	span0 := newSpan(0, 0, 255)
+	server := newSpanServer(t, map[string]*observer.HeimdallSpan{
+		"/bor/spans/0": span0,
+	})
+	defer server.Close()
+
+	h := newProvider(server.URL, nil)
+	span, err := h.fetchSpan("0")
+
+	if err != nil {
+		t.Fatalf("expected no error for valid span 0, got: %v", err)
+	}
+
+	if span.ID != 0 {
+		t.Errorf("expected span ID 0, got %d", span.ID)
+	}
+	if span.EndBlock != 255 {
+		t.Errorf("expected EndBlock 255, got %d", span.EndBlock)
+	}
+}
+
+func TestRefreshSpan_ExcessiveLagJumpsToLatest(t *testing.T) {
+	// When lag exceeds maxSpanLag, should jump directly to latest
+	server := newSpanServer(t, map[string]*observer.HeimdallSpan{
+		"/bor/spans/latest": newSpan(120, 12000, 12099),
+	})
+	defer server.Close()
+
+	// Current span is 100, latest is 120, lag = 20
+	// With maxSpanLag = 5, should jump to latest
+	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 5)
+
+	if err := h.refreshSpan(); err != nil {
+		t.Fatalf("refreshSpan() error: %v", err)
+	}
+
+	if h.spans.Curr.ID != 120 {
+		t.Errorf("expected to jump to latest span 120, got %d", h.spans.Curr.ID)
+	}
+	if h.spans.Prev == nil || h.spans.Prev.ID != 100 {
+		t.Errorf("expected Prev to be 100, got %v", h.spans.Prev)
+	}
+}
+
+func TestRefreshSpan_WithinLagWalksSequentially(t *testing.T) {
+	// When lag is within maxSpanLag, should walk sequentially
+	server := newSpanServer(t, map[string]*observer.HeimdallSpan{
+		"/bor/spans/latest": newSpan(105, 10500, 10599),
+		"/bor/spans/101":    newSpan(101, 10100, 10199),
+	})
+	defer server.Close()
+
+	// Current span is 100, latest is 105, lag = 5
+	// With maxSpanLag = 10, should walk sequentially
+	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 10)
+
+	if err := h.refreshSpan(); err != nil {
+		t.Fatalf("refreshSpan() error: %v", err)
+	}
+
+	// Should advance to 101, not jump to 105
+	if h.spans.Curr.ID != 101 {
+		t.Errorf("expected sequential walk to span 101, got %d", h.spans.Curr.ID)
+	}
+	if h.spans.Prev == nil || h.spans.Prev.ID != 100 {
+		t.Errorf("expected Prev to be 100, got %v", h.spans.Prev)
+	}
+}
+
+func TestRefreshSpan_ExactLagThresholdWalksSequentially(t *testing.T) {
+	// When lag equals maxSpanLag exactly, should still walk sequentially
+	server := newSpanServer(t, map[string]*observer.HeimdallSpan{
+		"/bor/spans/latest": newSpan(110, 11000, 11099),
+		"/bor/spans/101":    newSpan(101, 10100, 10199),
+	})
+	defer server.Close()
+
+	// Current span is 100, latest is 110, lag = 10
+	// With maxSpanLag = 10, should walk sequentially (lag is not > maxSpanLag)
+	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 10)
+
+	if err := h.refreshSpan(); err != nil {
+		t.Fatalf("refreshSpan() error: %v", err)
+	}
+
+	// Should advance to 101, not jump to 110
+	if h.spans.Curr.ID != 101 {
+		t.Errorf("expected sequential walk to span 101, got %d", h.spans.Curr.ID)
 	}
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

When heimdall-api returns a 5xx with a JSON error envelope, the body was decoding into a zero-value struct (ID=0, StartBlock=0, EndBlock=0), causing panoptichain to treat it as a real span and walk +1 per tick.

Changes:
- Add HTTP status code validation in api.GetJSON before JSON decoding
- Reject zero-value spans in fetchSpan as defense-in-depth
- Cap sequential span walking with configurable max_span_lag (default 10) to prevent multi-hour catch-up walks after transient failures

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
