### PR TITLE
feat(observer): init validator set change counters to zero

### DIFF
--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -523,6 +523,11 @@ func (o *HeimdallValidatorSetChangeObserver) Register(eb *EventBus) {
 		"The number of validator set changes (onboarded or unbonded)",
 		"change_type",
 	)
+
+	for _, h := range config.Config().Providers.HeimdallEndpoints {
+		o.counter.WithLabelValues(h.Name, h.Label, "onboarded").Add(0)
+		o.counter.WithLabelValues(h.Name, h.Label, "unbonded").Add(0)
+	}
 }
 
 func (o *HeimdallValidatorSetChangeObserver) Notify(ctx context.Context, m Message) {


### PR DESCRIPTION
Initialize the panoptichain_heimdall_validator_set_change counter with both change_type label values ("onboarded" and "unbonded") to zero on startup, matching the pattern used by other observers.

# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
