### PR TITLE
feat(observer): add staking event metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,13 +91,13 @@ type Rollup struct {
 // transactions on the network and records how long they took to be recorded in
 // a block.
 type TimeToMine struct {
-	Sender           string `mapstructure:"sender" validate:"required"`
-	SenderPrivateKey string `mapstructure:"sender_private_key" validate:"required"`
-	Receiver         string `mapstructure:"receiver" validate:"required"`
-	Value            int64  `mapstructure:"value" validate:"required"`
-	Data             string `mapstructure:"data"`
-	GasPriceFactor   int64  `mapstructure:"gas_price_factor"`
-	GasLimit         uint64 `mapstructure:"gas_limit" validate:"required"`
+	Sender           string  `mapstructure:"sender" validate:"required"`
+	SenderPrivateKey string  `mapstructure:"sender_private_key" validate:"required"`
+	Receiver         string  `mapstructure:"receiver" validate:"required"`
+	Value            int64   `mapstructure:"value" validate:"required"`
+	Data             string  `mapstructure:"data"`
+	GasPriceFactor   int64   `mapstructure:"gas_price_factor"`
+	GasLimit         uint64  `mapstructure:"gas_limit" validate:"required"`
 	SendMethod       *string `mapstructure:"send_method"`
 }
 

--- a/contracts/StakingInfo.abi.json
+++ b/contracts/StakingInfo.abi.json
@@ -1,0 +1,88 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "activationEpoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "total",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "signerPubkey",
+        "type": "bytes"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "deactivationEpoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnstakeInit",
+    "type": "event"
+  }
+]

--- a/contracts/StakingInfo.go
+++ b/contracts/StakingInfo.go
@@ -1,0 +1,515 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package contracts
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// StakingInfoMetaData contains all meta data concerning the StakingInfo contract.
+var StakingInfoMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"validatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"activationEpoch\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"total\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"signerPubkey\",\"type\":\"bytes\"}],\"name\":\"Staked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"user\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"validatorId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"deactivationEpoch\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"UnstakeInit\",\"type\":\"event\"}]",
+}
+
+// StakingInfoABI is the input ABI used to generate the binding from.
+// Deprecated: Use StakingInfoMetaData.ABI instead.
+var StakingInfoABI = StakingInfoMetaData.ABI
+
+// StakingInfo is an auto generated Go binding around an Ethereum contract.
+type StakingInfo struct {
+	StakingInfoCaller     // Read-only binding to the contract
+	StakingInfoTransactor // Write-only binding to the contract
+	StakingInfoFilterer   // Log filterer for contract events
+}
+
+// StakingInfoCaller is an auto generated read-only Go binding around an Ethereum contract.
+type StakingInfoCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingInfoTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type StakingInfoTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingInfoFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type StakingInfoFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingInfoSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type StakingInfoSession struct {
+	Contract     *StakingInfo      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// StakingInfoCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type StakingInfoCallerSession struct {
+	Contract *StakingInfoCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// StakingInfoTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type StakingInfoTransactorSession struct {
+	Contract     *StakingInfoTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// StakingInfoRaw is an auto generated low-level Go binding around an Ethereum contract.
+type StakingInfoRaw struct {
+	Contract *StakingInfo // Generic contract binding to access the raw methods on
+}
+
+// StakingInfoCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type StakingInfoCallerRaw struct {
+	Contract *StakingInfoCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// StakingInfoTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type StakingInfoTransactorRaw struct {
+	Contract *StakingInfoTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewStakingInfo creates a new instance of StakingInfo, bound to a specific deployed contract.
+func NewStakingInfo(address common.Address, backend bind.ContractBackend) (*StakingInfo, error) {
+	contract, err := bindStakingInfo(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfo{StakingInfoCaller: StakingInfoCaller{contract: contract}, StakingInfoTransactor: StakingInfoTransactor{contract: contract}, StakingInfoFilterer: StakingInfoFilterer{contract: contract}}, nil
+}
+
+// NewStakingInfoCaller creates a new read-only instance of StakingInfo, bound to a specific deployed contract.
+func NewStakingInfoCaller(address common.Address, caller bind.ContractCaller) (*StakingInfoCaller, error) {
+	contract, err := bindStakingInfo(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfoCaller{contract: contract}, nil
+}
+
+// NewStakingInfoTransactor creates a new write-only instance of StakingInfo, bound to a specific deployed contract.
+func NewStakingInfoTransactor(address common.Address, transactor bind.ContractTransactor) (*StakingInfoTransactor, error) {
+	contract, err := bindStakingInfo(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfoTransactor{contract: contract}, nil
+}
+
+// NewStakingInfoFilterer creates a new log filterer instance of StakingInfo, bound to a specific deployed contract.
+func NewStakingInfoFilterer(address common.Address, filterer bind.ContractFilterer) (*StakingInfoFilterer, error) {
+	contract, err := bindStakingInfo(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfoFilterer{contract: contract}, nil
+}
+
+// bindStakingInfo binds a generic wrapper to an already deployed contract.
+func bindStakingInfo(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := StakingInfoMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_StakingInfo *StakingInfoRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _StakingInfo.Contract.StakingInfoCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_StakingInfo *StakingInfoRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _StakingInfo.Contract.StakingInfoTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_StakingInfo *StakingInfoRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _StakingInfo.Contract.StakingInfoTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_StakingInfo *StakingInfoCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _StakingInfo.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_StakingInfo *StakingInfoTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _StakingInfo.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_StakingInfo *StakingInfoTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _StakingInfo.Contract.contract.Transact(opts, method, params...)
+}
+
+// StakingInfoStakedIterator is returned from FilterStaked and is used to iterate over the raw logs and unpacked data for Staked events raised by the StakingInfo contract.
+type StakingInfoStakedIterator struct {
+	Event *StakingInfoStaked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StakingInfoStakedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StakingInfoStaked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StakingInfoStaked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StakingInfoStakedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StakingInfoStakedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StakingInfoStaked represents a Staked event raised by the StakingInfo contract.
+type StakingInfoStaked struct {
+	Signer          common.Address
+	ValidatorId     *big.Int
+	Nonce           *big.Int
+	ActivationEpoch *big.Int
+	Amount          *big.Int
+	Total           *big.Int
+	SignerPubkey    []byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterStaked is a free log retrieval operation binding the contract event 0x68c13e4125b983d7e2d6114246f443e567ec6c4ee5b4d4a7ef6100b1402bfd84.
+//
+// Solidity: event Staked(address indexed signer, uint256 indexed validatorId, uint256 nonce, uint256 indexed activationEpoch, uint256 amount, uint256 total, bytes signerPubkey)
+func (_StakingInfo *StakingInfoFilterer) FilterStaked(opts *bind.FilterOpts, signer []common.Address, validatorId []*big.Int, activationEpoch []*big.Int) (*StakingInfoStakedIterator, error) {
+
+	var signerRule []interface{}
+	for _, signerItem := range signer {
+		signerRule = append(signerRule, signerItem)
+	}
+	var validatorIdRule []interface{}
+	for _, validatorIdItem := range validatorId {
+		validatorIdRule = append(validatorIdRule, validatorIdItem)
+	}
+
+	var activationEpochRule []interface{}
+	for _, activationEpochItem := range activationEpoch {
+		activationEpochRule = append(activationEpochRule, activationEpochItem)
+	}
+
+	logs, sub, err := _StakingInfo.contract.FilterLogs(opts, "Staked", signerRule, validatorIdRule, activationEpochRule)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfoStakedIterator{contract: _StakingInfo.contract, event: "Staked", logs: logs, sub: sub}, nil
+}
+
+// WatchStaked is a free log subscription operation binding the contract event 0x68c13e4125b983d7e2d6114246f443e567ec6c4ee5b4d4a7ef6100b1402bfd84.
+//
+// Solidity: event Staked(address indexed signer, uint256 indexed validatorId, uint256 nonce, uint256 indexed activationEpoch, uint256 amount, uint256 total, bytes signerPubkey)
+func (_StakingInfo *StakingInfoFilterer) WatchStaked(opts *bind.WatchOpts, sink chan<- *StakingInfoStaked, signer []common.Address, validatorId []*big.Int, activationEpoch []*big.Int) (event.Subscription, error) {
+
+	var signerRule []interface{}
+	for _, signerItem := range signer {
+		signerRule = append(signerRule, signerItem)
+	}
+	var validatorIdRule []interface{}
+	for _, validatorIdItem := range validatorId {
+		validatorIdRule = append(validatorIdRule, validatorIdItem)
+	}
+
+	var activationEpochRule []interface{}
+	for _, activationEpochItem := range activationEpoch {
+		activationEpochRule = append(activationEpochRule, activationEpochItem)
+	}
+
+	logs, sub, err := _StakingInfo.contract.WatchLogs(opts, "Staked", signerRule, validatorIdRule, activationEpochRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StakingInfoStaked)
+				if err := _StakingInfo.contract.UnpackLog(event, "Staked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStaked is a log parse operation binding the contract event 0x68c13e4125b983d7e2d6114246f443e567ec6c4ee5b4d4a7ef6100b1402bfd84.
+//
+// Solidity: event Staked(address indexed signer, uint256 indexed validatorId, uint256 nonce, uint256 indexed activationEpoch, uint256 amount, uint256 total, bytes signerPubkey)
+func (_StakingInfo *StakingInfoFilterer) ParseStaked(log types.Log) (*StakingInfoStaked, error) {
+	event := new(StakingInfoStaked)
+	if err := _StakingInfo.contract.UnpackLog(event, "Staked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// StakingInfoUnstakeInitIterator is returned from FilterUnstakeInit and is used to iterate over the raw logs and unpacked data for UnstakeInit events raised by the StakingInfo contract.
+type StakingInfoUnstakeInitIterator struct {
+	Event *StakingInfoUnstakeInit // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StakingInfoUnstakeInitIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StakingInfoUnstakeInit)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StakingInfoUnstakeInit)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StakingInfoUnstakeInitIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StakingInfoUnstakeInitIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StakingInfoUnstakeInit represents a UnstakeInit event raised by the StakingInfo contract.
+type StakingInfoUnstakeInit struct {
+	User              common.Address
+	ValidatorId       *big.Int
+	Nonce             *big.Int
+	DeactivationEpoch *big.Int
+	Amount            *big.Int
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnstakeInit is a free log retrieval operation binding the contract event 0x69b288bb79cd5386c9fe0af060f650e823bcdfa96a44cdc07f862db060f57120.
+//
+// Solidity: event UnstakeInit(address indexed user, uint256 indexed validatorId, uint256 nonce, uint256 deactivationEpoch, uint256 indexed amount)
+func (_StakingInfo *StakingInfoFilterer) FilterUnstakeInit(opts *bind.FilterOpts, user []common.Address, validatorId []*big.Int, amount []*big.Int) (*StakingInfoUnstakeInitIterator, error) {
+
+	var userRule []interface{}
+	for _, userItem := range user {
+		userRule = append(userRule, userItem)
+	}
+	var validatorIdRule []interface{}
+	for _, validatorIdItem := range validatorId {
+		validatorIdRule = append(validatorIdRule, validatorIdItem)
+	}
+
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _StakingInfo.contract.FilterLogs(opts, "UnstakeInit", userRule, validatorIdRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingInfoUnstakeInitIterator{contract: _StakingInfo.contract, event: "UnstakeInit", logs: logs, sub: sub}, nil
+}
+
+// WatchUnstakeInit is a free log subscription operation binding the contract event 0x69b288bb79cd5386c9fe0af060f650e823bcdfa96a44cdc07f862db060f57120.
+//
+// Solidity: event UnstakeInit(address indexed user, uint256 indexed validatorId, uint256 nonce, uint256 deactivationEpoch, uint256 indexed amount)
+func (_StakingInfo *StakingInfoFilterer) WatchUnstakeInit(opts *bind.WatchOpts, sink chan<- *StakingInfoUnstakeInit, user []common.Address, validatorId []*big.Int, amount []*big.Int) (event.Subscription, error) {
+
+	var userRule []interface{}
+	for _, userItem := range user {
+		userRule = append(userRule, userItem)
+	}
+	var validatorIdRule []interface{}
+	for _, validatorIdItem := range validatorId {
+		validatorIdRule = append(validatorIdRule, validatorIdItem)
+	}
+
+	var amountRule []interface{}
+	for _, amountItem := range amount {
+		amountRule = append(amountRule, amountItem)
+	}
+
+	logs, sub, err := _StakingInfo.contract.WatchLogs(opts, "UnstakeInit", userRule, validatorIdRule, amountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StakingInfoUnstakeInit)
+				if err := _StakingInfo.contract.UnpackLog(event, "UnstakeInit", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnstakeInit is a log parse operation binding the contract event 0x69b288bb79cd5386c9fe0af060f650e823bcdfa96a44cdc07f862db060f57120.
+//
+// Solidity: event UnstakeInit(address indexed user, uint256 indexed validatorId, uint256 nonce, uint256 deactivationEpoch, uint256 indexed amount)
+func (_StakingInfo *StakingInfoFilterer) ParseUnstakeInit(log types.Log) (*StakingInfoUnstakeInit, error) {
+	event := new(StakingInfoUnstakeInit)
+	if err := _StakingInfo.contract.UnpackLog(event, "UnstakeInit", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/metrics.md
+++ b/metrics.md
@@ -1168,6 +1168,15 @@ Variable Labels:
 - network
 - provider
 
+### panoptichain_rpc_validator_set_size
+The current number of active validators
+
+Metric Type: GaugeVec
+
+Variable Labels:
+- network
+- provider
+
 ## StakingEventsObserver
 
 
@@ -1396,18 +1405,6 @@ Variable Labels:
 The number of uncles for the block
 
 Metric Type: CounterVec
-
-Variable Labels:
-- network
-- provider
-
-## ValidatorSetSizeObserver
-
-
-### panoptichain_rpc_validator_set_size
-The current number of active validators
-
-Metric Type: GaugeVec
 
 Variable Labels:
 - network

--- a/metrics.md
+++ b/metrics.md
@@ -1168,6 +1168,31 @@ Variable Labels:
 - network
 - provider
 
+## StakingEventsObserver
+
+
+### panoptichain_rpc_stake_for_pol
+The total number of Staked events observed
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- validator_id
+- signer_address
+
+### panoptichain_rpc_unstake_pol
+The total number of UnstakeInit events observed
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- validator_id
+- signer_address
+
 ## StateSyncObserver
 
 
@@ -1371,6 +1396,18 @@ Variable Labels:
 The number of uncles for the block
 
 Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+
+## ValidatorSetSizeObserver
+
+
+### panoptichain_rpc_validator_set_size
+The current number of active validators
+
+Metric Type: GaugeVec
 
 Variable Labels:
 - network

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -191,7 +191,6 @@ var observersMap = map[string]Observer{
 	"transaction_value":                   new(TransactionValueObserver),
 	"trusted_batch":                       new(TrustedBatchObserver),
 	"uncles":                              new(UnclesObserver),
-	"validator_set_size":                  new(ValidatorSetSizeObserver),
 	"validator_wallet_balance":            new(ValidatorWalletBalanceObserver),
 	"zkevm_batches":                       new(ZkEVMBatchObserver),
 }

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -177,6 +177,7 @@ var observersMap = map[string]Observer{
 	"state_sync":                          new(StateSyncObserver),
 	"stolen_block":                        new(StolenBlockObserver),
 	"spn_proof_request":                   new(ProofRequestObserver),
+	"staking_events":                      new(StakingEventsObserver),
 	"system":                              new(SystemObserver),
 	"time_to_finalized":                   new(TimeToFinalizedObserver),
 	"time_to_mine":                        new(TimeToMineObserver),
@@ -190,6 +191,7 @@ var observersMap = map[string]Observer{
 	"transaction_value":                   new(TransactionValueObserver),
 	"trusted_batch":                       new(TrustedBatchObserver),
 	"uncles":                              new(UnclesObserver),
+	"validator_set_size":                  new(ValidatorSetSizeObserver),
 	"validator_wallet_balance":            new(ValidatorWalletBalanceObserver),
 	"zkevm_batches":                       new(ZkEVMBatchObserver),
 }
@@ -296,4 +298,3 @@ func NewLogger(o Observer, m Message) zerolog.Logger {
 		Str("provider", m.Provider()).Time("time", m.Time()).
 		Logger()
 }
-

--- a/observer/rpc.go
+++ b/observer/rpc.go
@@ -1709,7 +1709,13 @@ func (o *TimeToFinalizedObserver) GetCollectors() []prometheus.Collector {
 }
 
 type StakeManager struct {
-	TotalStaked *big.Int
+	TotalStaked      *big.Int
+	ValidatorSetSize *big.Int
+}
+
+type StakingEvents struct {
+	StakedEvents      []*contracts.StakingInfoStaked
+	UnstakeInitEvents []*contracts.StakingInfoUnstakeInit
 }
 
 type StakeManagerObserver struct {
@@ -1737,4 +1743,92 @@ func (o *StakeManagerObserver) Register(eb *EventBus) {
 
 func (o *StakeManagerObserver) GetCollectors() []prometheus.Collector {
 	return []prometheus.Collector{o.totalStaked}
+}
+
+type StakingEventsObserver struct {
+	stakeCounter   *prometheus.CounterVec
+	unstakeCounter *prometheus.CounterVec
+}
+
+func (o *StakingEventsObserver) Notify(ctx context.Context, m Message) {
+	logger := NewLogger(o, m)
+
+	data := m.Data().(*StakingEvents)
+
+	for _, event := range data.StakedEvents {
+		validatorID := event.ValidatorId.String()
+		signerAddress := event.Signer.Hex()
+
+		logger.Info().
+			Str("validator_id", validatorID).
+			Str("signer_address", signerAddress).
+			Str("amount", event.Amount.String()).
+			Msg("Staked event detected")
+
+		o.stakeCounter.WithLabelValues(m.Network().GetName(), m.Provider(), validatorID, signerAddress).Inc()
+	}
+
+	for _, event := range data.UnstakeInitEvents {
+		validatorID := event.ValidatorId.String()
+		signerAddress := event.User.Hex()
+
+		logger.Info().
+			Str("validator_id", validatorID).
+			Str("signer_address", signerAddress).
+			Str("amount", event.Amount.String()).
+			Msg("UnstakeInit event detected")
+
+		o.unstakeCounter.WithLabelValues(m.Network().GetName(), m.Provider(), validatorID, signerAddress).Inc()
+	}
+}
+
+func (o *StakingEventsObserver) Register(eb *EventBus) {
+	eb.Subscribe(topics.StakingEvents, o)
+
+	o.stakeCounter = metrics.NewCounter(
+		metrics.RPC,
+		"stake_for_pol",
+		"The total number of Staked events observed",
+		"validator_id",
+		"signer_address",
+	)
+
+	o.unstakeCounter = metrics.NewCounter(
+		metrics.RPC,
+		"unstake_pol",
+		"The total number of UnstakeInit events observed",
+		"validator_id",
+		"signer_address",
+	)
+}
+
+func (o *StakingEventsObserver) GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{o.stakeCounter, o.unstakeCounter}
+}
+
+type ValidatorSetSizeObserver struct {
+	gauge *prometheus.GaugeVec
+}
+
+func (o *ValidatorSetSizeObserver) Notify(ctx context.Context, m Message) {
+	data := m.Data().(*StakeManager)
+
+	if data.ValidatorSetSize != nil {
+		size, _ := data.ValidatorSetSize.Float64()
+		o.gauge.WithLabelValues(m.Network().GetName(), m.Provider()).Set(size)
+	}
+}
+
+func (o *ValidatorSetSizeObserver) Register(eb *EventBus) {
+	eb.Subscribe(topics.StakeManager, o)
+
+	o.gauge = metrics.NewGauge(
+		metrics.RPC,
+		"validator_set_size",
+		"The current number of active validators",
+	)
+}
+
+func (o *ValidatorSetSizeObserver) GetCollectors() []prometheus.Collector {
+	return []prometheus.Collector{o.gauge}
 }

--- a/observer/rpc.go
+++ b/observer/rpc.go
@@ -1719,7 +1719,8 @@ type StakingEvents struct {
 }
 
 type StakeManagerObserver struct {
-	totalStaked *prometheus.GaugeVec
+	totalStaked      *prometheus.GaugeVec
+	validatorSetSize *prometheus.GaugeVec
 }
 
 func (o *StakeManagerObserver) Notify(ctx context.Context, m Message) {
@@ -1728,6 +1729,11 @@ func (o *StakeManagerObserver) Notify(ctx context.Context, m Message) {
 	if data.TotalStaked != nil {
 		totalStaked, _ := weiToEther(data.TotalStaked).Float64()
 		o.totalStaked.WithLabelValues(m.Network().GetName(), m.Provider()).Set(totalStaked)
+	}
+
+	if data.ValidatorSetSize != nil {
+		size, _ := data.ValidatorSetSize.Float64()
+		o.validatorSetSize.WithLabelValues(m.Network().GetName(), m.Provider()).Set(size)
 	}
 }
 
@@ -1739,10 +1745,16 @@ func (o *StakeManagerObserver) Register(eb *EventBus) {
 		"total_staked",
 		"Total amount staked in the stake manager contract (in ether)",
 	)
+
+	o.validatorSetSize = metrics.NewGauge(
+		metrics.RPC,
+		"validator_set_size",
+		"The current number of active validators",
+	)
 }
 
 func (o *StakeManagerObserver) GetCollectors() []prometheus.Collector {
-	return []prometheus.Collector{o.totalStaked}
+	return []prometheus.Collector{o.totalStaked, o.validatorSetSize}
 }
 
 type StakingEventsObserver struct {
@@ -1804,31 +1816,4 @@ func (o *StakingEventsObserver) Register(eb *EventBus) {
 
 func (o *StakingEventsObserver) GetCollectors() []prometheus.Collector {
 	return []prometheus.Collector{o.stakeCounter, o.unstakeCounter}
-}
-
-type ValidatorSetSizeObserver struct {
-	gauge *prometheus.GaugeVec
-}
-
-func (o *ValidatorSetSizeObserver) Notify(ctx context.Context, m Message) {
-	data := m.Data().(*StakeManager)
-
-	if data.ValidatorSetSize != nil {
-		size, _ := data.ValidatorSetSize.Float64()
-		o.gauge.WithLabelValues(m.Network().GetName(), m.Provider()).Set(size)
-	}
-}
-
-func (o *ValidatorSetSizeObserver) Register(eb *EventBus) {
-	eb.Subscribe(topics.StakeManager, o)
-
-	o.gauge = metrics.NewGauge(
-		metrics.RPC,
-		"validator_set_size",
-		"The current number of active validators",
-	)
-}
-
-func (o *ValidatorSetSizeObserver) GetCollectors() []prometheus.Collector {
-	return []prometheus.Collector{o.gauge}
 }

--- a/observer/topics/observabletopic_string.go
+++ b/observer/topics/observabletopic_string.go
@@ -51,11 +51,12 @@ func _() {
 	_ = x[MissedVote-40]
 	_ = x[MilestoneVote-41]
 	_ = x[ZkEVMBatches-42]
+	_ = x[StakingEvents-43]
 }
 
-const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteMilestoneVoteZkEVMBatches"
+const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteMilestoneVoteZkEVMBatchesStakingEvents"
 
-var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 447, 453, 468, 478, 493, 505, 520, 532, 542, 555, 567}
+var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 447, 453, 468, 478, 493, 505, 520, 532, 542, 555, 567, 580}
 
 func (i ObservableTopic) String() string {
 	idx := int(i) - 0

--- a/observer/topics/topics.go
+++ b/observer/topics/topics.go
@@ -47,4 +47,5 @@ const (
 	MissedVote                                         // *observer.HeimdallMissedVotes
 	MilestoneVote                                      // *observer.HeimdallMilestoneVotes
 	ZkEVMBatches                                       // observer.ZkEVMBatches
+	StakingEvents                                      // *observer.StakingEvents
 )

--- a/provider/rpc.go
+++ b/provider/rpc.go
@@ -63,6 +63,8 @@ type RPCProvider struct {
 	validatorBalances    observer.ValidatorWalletBalances
 	missedBlockProposal  observer.MissedBlockProposal
 	stakeManager         *observer.StakeManager
+	stakingEvents        *observer.StakingEvents
+	stakingInfoAddress   *common.Address
 
 	// zkEVM
 	batches        observer.ZkEVMBatches
@@ -157,6 +159,7 @@ func (r *RPCProvider) RefreshState(ctx context.Context) error {
 	}
 
 	r.refreshStakeManager(ctx, c)
+	r.refreshStakingEvents(ctx, c)
 
 	if r.hasTxPool {
 		r.refreshTxPoolStatus(ctx, c)
@@ -310,6 +313,11 @@ func (r *RPCProvider) PublishEvents(ctx context.Context) error {
 		r.bus.Publish(ctx, topics.StakeManager, m)
 	}
 
+	if r.stakingEvents != nil {
+		m := observer.NewMessage(r.network, r.label, r.stakingEvents)
+		r.bus.Publish(ctx, topics.StakingEvents, m)
+	}
+
 	r.bus.Publish(ctx, topics.RefreshStateTime, observer.NewMessage(r.network, r.label, r.refreshStateTime))
 
 	return nil
@@ -440,14 +448,74 @@ func (r *RPCProvider) refreshStakeManager(ctx context.Context, c *ethclient.Clie
 	}
 
 	co := bind.CallOpts{Context: ctx}
+
+	stakingInfoAddress, err := contract.Logger(&co)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Failed to get staking info address from stake manager")
+	} else {
+		r.stakingInfoAddress = &stakingInfoAddress
+	}
+
 	totalStaked, err := contract.CurrentValidatorSetTotalStake(&co)
 	if err != nil {
 		r.logger.Error().Err(err).Msg("Failed to get current validator set total stake")
 		return err
 	}
 
+	validatorSetSize, err := contract.CurrentValidatorSetSize(&co)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Failed to get current validator set size")
+		return err
+	}
+
 	r.stakeManager = &observer.StakeManager{
-		TotalStaked: totalStaked,
+		TotalStaked:      totalStaked,
+		ValidatorSetSize: validatorSetSize,
+	}
+
+	return nil
+}
+
+func (r *RPCProvider) refreshStakingEvents(ctx context.Context, c *ethclient.Client) error {
+	if r.stakingInfoAddress == nil {
+		return nil
+	}
+
+	r.stakingEvents = nil
+
+	stakingInfo, err := contracts.NewStakingInfo(*r.stakingInfoAddress, c)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Failed to bind staking info contract")
+		return err
+	}
+
+	opts := r.getFilterOpts()
+
+	stakedEvents := make([]*contracts.StakingInfoStaked, 0)
+	stakedIter, err := stakingInfo.FilterStaked(opts, nil, nil, nil)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Failed to filter Staked events")
+	} else {
+		for stakedIter.Next() && stakedIter.Event != nil {
+			stakedEvents = append(stakedEvents, stakedIter.Event)
+		}
+	}
+
+	unstakeInitEvents := make([]*contracts.StakingInfoUnstakeInit, 0)
+	unstakeInitIter, err := stakingInfo.FilterUnstakeInit(opts, nil, nil, nil)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Failed to filter UnstakeInit events")
+	} else {
+		for unstakeInitIter.Next() && unstakeInitIter.Event != nil {
+			unstakeInitEvents = append(unstakeInitEvents, unstakeInitIter.Event)
+		}
+	}
+
+	if len(stakedEvents) > 0 || len(unstakeInitEvents) > 0 {
+		r.stakingEvents = &observer.StakingEvents{
+			StakedEvents:      stakedEvents,
+			UnstakeInitEvents: unstakeInitEvents,
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Add three new metrics for L1 PoS staking observability:
- stake_for_pol counter: counts Staked events with validator_id and signer_address labels
- unstake_pol counter: counts UnstakeInit events with validator_id and signer_address labels
- validator_set_size gauge: current number of active validators

Events are fetched from the StakingInfo contract (address obtained via StakeManager.Logger()).

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
