### PR TITLE
fix(observer): count all validators without milestone in missed metric

### DIFF
--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -15,7 +15,6 @@ import (
 	"github.com/0xPolygon/panoptichain/config"
 	"github.com/0xPolygon/panoptichain/metrics"
 	"github.com/0xPolygon/panoptichain/observer/topics"
-	"github.com/0xPolygon/panoptichain/proto/heimdall"
 )
 
 type PreCommit struct {
@@ -714,8 +713,8 @@ func (o *HeimdallMilestoneVoteObserver) Notify(ctx context.Context, m Message) {
 		switch {
 		case vote.HasMilestone:
 			o.proposed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
-		case vote.BlockIDFlag == heimdall.BlockIDFlagCommit:
-			// Signed the block but did not propose milestone
+		default:
+			// Did not propose milestone (regardless of whether they signed)
 			o.missed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
 		}
 	}


### PR DESCRIPTION
Previously milestone_vote_missed only counted validators who signed the block but didn't propose a milestone. Validators who were ABSENT or voted NIL were not counted, even though they also didn't propose milestones.

Change the logic to count ALL validators without a milestone, regardless of their signing status.

# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
