### PR TITLE
fix(observer): correct milestone_observed counter undercounting

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -514,7 +514,7 @@ Variable Labels:
 - signer_address
 
 ### panoptichain_heimdall_milestone_vote_missed
-Validators who signed but didn't propose milestone
+Validators who didn't propose milestone
 
 Metric Type: CounterVec
 

--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -245,7 +245,6 @@ type HeimdallMilestone struct {
 	MilestoneID string `json:"milestone_id"`
 	Timestamp   int64  `json:"timestamp,string"`
 	Count       int64
-	PrevCount   int64
 }
 
 type HeimdallMilestoneV2 struct {
@@ -265,18 +264,14 @@ func (o *MilestoneObserver) Notify(ctx context.Context, m Message) {
 	milestone := m.Data().(*HeimdallMilestone)
 
 	seconds := time.Since(time.Unix(milestone.Timestamp, 0)).Seconds()
-	startBlock := milestone.StartBlock
-	endBlock := milestone.EndBlock
 
 	o.count.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.Count))
 	o.time.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(seconds))
 	o.startBlock.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.StartBlock))
 	o.endBlock.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.EndBlock))
 
-	if milestone.Count > milestone.PrevCount {
-		o.observed.WithLabelValues(m.Network().GetName(), m.Provider()).Inc()
-		o.blockRange.WithLabelValues(m.Network().GetName(), m.Provider()).Observe(float64(endBlock - startBlock))
-	}
+	o.observed.WithLabelValues(m.Network().GetName(), m.Provider()).Inc()
+	o.blockRange.WithLabelValues(m.Network().GetName(), m.Provider()).Observe(float64(milestone.EndBlock - milestone.StartBlock))
 }
 
 func (o *MilestoneObserver) Register(eb *EventBus) {
@@ -700,7 +695,7 @@ func (o *HeimdallMilestoneVoteObserver) Register(eb *EventBus) {
 	o.missed = metrics.NewCounter(
 		metrics.Heimdall,
 		"milestone_vote_missed",
-		"Validators who signed but didn't propose milestone",
+		"Validators who didn't propose milestone",
 		"validator_id", "signer_address",
 	)
 

--- a/provider/heimdall.go
+++ b/provider/heimdall.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"net/url"
 	"sort"
 	"strconv"
@@ -48,7 +47,7 @@ type HeimdallProvider struct {
 	checkpointProposers       *orderedmap.OrderedMap[string, struct{}]
 	missedCheckpointProposers []string
 
-	milestone          *observer.HeimdallMilestone
+	milestones         []*observer.HeimdallMilestone
 	prevMilestoneCount int64
 
 	spans *observer.HeimdallSpans
@@ -164,8 +163,8 @@ func (h *HeimdallProvider) PublishEvents(ctx context.Context) error {
 		h.bus.Publish(ctx, topics.MissedCheckpointProposal, m)
 	}
 
-	if h.milestone != nil {
-		m := observer.NewMessage(h.network, h.label, h.milestone)
+	for _, milestone := range h.milestones {
+		m := observer.NewMessage(h.network, h.label, milestone)
 		h.bus.Publish(ctx, topics.Milestone, m)
 	}
 
@@ -309,48 +308,41 @@ func (h *HeimdallProvider) fillRange(start uint64) {
 	}
 }
 
-func (h *HeimdallProvider) getHeimdallMilestoneCount() (*big.Int, error) {
+func (h *HeimdallProvider) refreshMilestone() error {
 	path, err := url.JoinPath(h.heimdallURL, "milestones", "count")
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone count path")
-		return nil, err
+		return err
 	}
 
 	var count observer.HeimdallMilestoneCount
 	if err := api.GetJSON(path, &count); err != nil {
-		return nil, err
-	}
-
-	return new(big.Int).SetUint64(count.Count), nil
-}
-
-func (h *HeimdallProvider) refreshMilestone() error {
-	if h.milestone != nil {
-		h.prevMilestoneCount = h.milestone.Count
-	}
-
-	count, err := h.getHeimdallMilestoneCount()
-	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone count")
 		return err
 	}
 
-	path, err := url.JoinPath(h.heimdallURL, "milestones", count.String())
-	if err != nil {
-		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone path")
-		return err
+	currentCount := int64(count.Count)
+	h.milestones = nil
+
+	for i := h.prevMilestoneCount + 1; i <= currentCount; i++ {
+		path, err := url.JoinPath(h.heimdallURL, "milestones", strconv.FormatInt(i, 10))
+		if err != nil {
+			h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone path")
+			continue
+		}
+
+		var v2 observer.HeimdallMilestoneV2
+		if err = api.GetJSON(path, &v2); err != nil {
+			h.logger.Error().Err(err).Int64("milestone", i).Msg("Failed to get Heimdall milestone")
+			continue
+		}
+
+		milestone := &v2.Milestone
+		milestone.Count = i
+		h.milestones = append(h.milestones, milestone)
 	}
 
-	var v2 observer.HeimdallMilestoneV2
-	if err = api.GetJSON(path, &v2); err != nil {
-		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone")
-		return err
-	}
-
-	h.milestone = &v2.Milestone
-	h.milestone.PrevCount = h.prevMilestoneCount
-	h.milestone.Count = count.Int64()
-
+	h.prevMilestoneCount = currentCount
 	return nil
 }
 


### PR DESCRIPTION

# Description

The milestone_observed counter was only incrementing by 1 per polling cycle, even when multiple milestones occurred between polls. This was because the provider only fetched the latest milestone and the observer only called Inc() once.

Changes:
- Fetch all milestones in range (prevCount+1 to currentCount) instead of just the latest, following the same pattern as milestoneVotes
- Publish each milestone individually so the observer increments once per milestone
- Remove PrevCount field from HeimdallMilestone (no longer needed)
- Simplify MilestoneObserver.Notify to always increment counters
- Fix misleading milestone_vote_missed description from "Validators who signed but didn't propose milestone" to "Validators who didn't propose milestone" (the metric tracks all validators without milestones, not just those who signed consensus)


<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
