### PR TITLE
fix(observer): handle first poll in milestone refresh

### DIFF
--- a/provider/heimdall.go
+++ b/provider/heimdall.go
@@ -324,7 +324,14 @@ func (h *HeimdallProvider) refreshMilestone() error {
 	currentCount := int64(count.Count)
 	h.milestones = nil
 
-	for i := h.prevMilestoneCount + 1; i <= currentCount; i++ {
+	// On first poll, fetch only the latest milestone to establish baseline.
+	// On subsequent polls, fetch all new milestones in range.
+	start := h.prevMilestoneCount + 1
+	if h.prevMilestoneCount == 0 {
+		start = currentCount
+	}
+
+	for i := start; i <= currentCount; i++ {
 		path, err := url.JoinPath(h.heimdallURL, "milestones", strconv.FormatInt(i, 10))
 		if err != nil {
 			h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone path")


### PR DESCRIPTION

# Description

On first poll, prevMilestoneCount is 0, causing the loop to attempt fetching all milestones from 1 to currentCount (potentially thousands).

Now on first poll, we fetch only the latest milestone to establish the baseline. On subsequent polls, we fetch all new milestones in range.


<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
