### PR TITLE
fix: milestone observed and voting parity

### DIFF
--- a/metrics.md
+++ b/metrics.md
@@ -613,6 +613,16 @@ Variable Labels:
 - network
 - provider
 
+### panoptichain_heimdall_milestone_proposed
+Milestones proposed by validator
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- proposer
+
 ### panoptichain_heimdall_milestone_block_range
 The number of blocks in the milestone
 

--- a/metrics.md
+++ b/metrics.md
@@ -499,51 +499,6 @@ Variable Labels:
 - network
 - provider
 
-## HeimdallMilestoneVoteObserver
-
-
-### panoptichain_heimdall_milestone_vote_proposed
-Validators who proposed milestone in vote extension
-
-Metric Type: CounterVec
-
-Variable Labels:
-- network
-- provider
-- validator_id
-- signer_address
-
-### panoptichain_heimdall_milestone_vote_missed
-Validators who didn't propose milestone
-
-Metric Type: CounterVec
-
-Variable Labels:
-- network
-- provider
-- validator_id
-- signer_address
-
-### panoptichain_heimdall_milestone_signed_but_missed
-Validators who signed consensus but didn't propose milestone
-
-Metric Type: CounterVec
-
-Variable Labels:
-- network
-- provider
-- validator_id
-- signer_address
-
-### panoptichain_heimdall_milestone_voting_power
-Percentage of voting power that proposed milestone
-
-Metric Type: GaugeVec
-
-Variable Labels:
-- network
-- provider
-
 ## HeimdallMissedBlockProposalObserver
 
 
@@ -662,6 +617,48 @@ Variable Labels:
 The number of blocks in the milestone
 
 Metric Type: HistogramVec
+
+Variable Labels:
+- network
+- provider
+
+### panoptichain_heimdall_milestone_vote_proposed
+Validators who proposed milestone in vote extension
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- validator_id
+- signer_address
+
+### panoptichain_heimdall_milestone_vote_missed
+Validators who didn't propose milestone
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- validator_id
+- signer_address
+
+### panoptichain_heimdall_milestone_signed_but_missed
+Validators who signed consensus but didn't propose milestone
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+- validator_id
+- signer_address
+
+### panoptichain_heimdall_milestone_voting_power
+Percentage of voting power that proposed milestone
+
+Metric Type: GaugeVec
 
 Variable Labels:
 - network

--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -245,6 +245,10 @@ type HeimdallMilestone struct {
 	MilestoneID string `json:"milestone_id"`
 	Timestamp   int64  `json:"timestamp,string"`
 	Count       int64
+
+	// Votes contains the milestone votes from the block where this milestone was finalized.
+	// This is populated by matching the milestone range to vote extensions.
+	Votes *HeimdallMilestoneVotes
 }
 
 type HeimdallMilestoneV2 struct {
@@ -258,20 +262,66 @@ type MilestoneObserver struct {
 	endBlock   *prometheus.GaugeVec
 	observed   *prometheus.CounterVec
 	blockRange *prometheus.HistogramVec
+
+	// Vote metrics (merged from HeimdallMilestoneVoteObserver)
+	voteProposed        *prometheus.CounterVec
+	voteMissed          *prometheus.CounterVec
+	voteSignedButMissed *prometheus.CounterVec
+	votingPower         *prometheus.GaugeVec
 }
 
 func (o *MilestoneObserver) Notify(ctx context.Context, m Message) {
+	logger := NewLogger(o, m)
 	milestone := m.Data().(*HeimdallMilestone)
+	network := m.Network().GetName()
+	provider := m.Provider()
 
 	seconds := time.Since(time.Unix(milestone.Timestamp, 0)).Seconds()
 
-	o.count.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.Count))
-	o.time.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(seconds))
-	o.startBlock.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.StartBlock))
-	o.endBlock.WithLabelValues(m.Network().GetName(), m.Provider()).Set(float64(milestone.EndBlock))
+	o.count.WithLabelValues(network, provider).Set(float64(milestone.Count))
+	o.time.WithLabelValues(network, provider).Set(float64(seconds))
+	o.startBlock.WithLabelValues(network, provider).Set(float64(milestone.StartBlock))
+	o.endBlock.WithLabelValues(network, provider).Set(float64(milestone.EndBlock))
 
-	o.observed.WithLabelValues(m.Network().GetName(), m.Provider()).Inc()
-	o.blockRange.WithLabelValues(m.Network().GetName(), m.Provider()).Observe(float64(milestone.EndBlock - milestone.StartBlock))
+	o.observed.WithLabelValues(network, provider).Inc()
+	o.blockRange.WithLabelValues(network, provider).Observe(float64(milestone.EndBlock - milestone.StartBlock))
+
+	// Process vote metrics if votes are attached
+	votes := milestone.Votes
+	if votes == nil {
+		return
+	}
+
+	var vpPct float64
+	if votes.TotalVotingPower > 0 {
+		vpPct = float64(votes.MilestoneVotingPower) / float64(votes.TotalVotingPower) * 100
+	}
+	o.votingPower.WithLabelValues(network, provider).Set(vpPct)
+
+	for _, vote := range votes.Votes {
+		id := strconv.FormatUint(vote.ValidatorID, 10)
+		switch {
+		case vote.HasMilestone:
+			o.voteProposed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
+		case vote.BlockIDFlag == heimdall.BlockIDFlagCommit:
+			// Signed consensus but didn't propose milestone
+			o.voteSignedButMissed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
+			o.voteMissed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
+		default:
+			// Absent/nil - didn't sign consensus and no milestone
+			o.voteMissed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
+		}
+	}
+
+	missed := votes.TotalValidators - votes.MilestoneVoters
+	if missed > 0 {
+		logger.Trace().
+			Uint64("height", votes.Height).
+			Int("total_validators", votes.TotalValidators).
+			Int("milestone_voters", votes.MilestoneVoters).
+			Int("missed", missed).
+			Msg("Detected validators without milestone vote")
+	}
 }
 
 func (o *MilestoneObserver) Register(eb *EventBus) {
@@ -289,6 +339,31 @@ func (o *MilestoneObserver) Register(eb *EventBus) {
 		newExponentialBuckets(2, 10),
 	)
 
+	// Vote metrics (merged from HeimdallMilestoneVoteObserver)
+	o.voteProposed = metrics.NewCounter(
+		metrics.Heimdall,
+		"milestone_vote_proposed",
+		"Validators who proposed milestone in vote extension",
+		"validator_id", "signer_address",
+	)
+	o.voteMissed = metrics.NewCounter(
+		metrics.Heimdall,
+		"milestone_vote_missed",
+		"Validators who didn't propose milestone",
+		"validator_id", "signer_address",
+	)
+	o.voteSignedButMissed = metrics.NewCounter(
+		metrics.Heimdall,
+		"milestone_signed_but_missed",
+		"Validators who signed consensus but didn't propose milestone",
+		"validator_id", "signer_address",
+	)
+	o.votingPower = metrics.NewGauge(
+		metrics.Heimdall,
+		"milestone_voting_power",
+		"Percentage of voting power that proposed milestone",
+	)
+
 	for _, h := range config.Config().Providers.HeimdallEndpoints {
 		o.observed.WithLabelValues(h.Name, h.Label).Add(0)
 	}
@@ -302,6 +377,10 @@ func (o *MilestoneObserver) GetCollectors() []prometheus.Collector {
 		o.endBlock,
 		o.observed,
 		o.blockRange,
+		o.voteProposed,
+		o.voteMissed,
+		o.voteSignedButMissed,
+		o.votingPower,
 	}
 }
 
@@ -672,85 +751,4 @@ func (o *HeimdallMissedVoteObserver) Notify(ctx context.Context, m Message) {
 
 func (o *HeimdallMissedVoteObserver) GetCollectors() []prometheus.Collector {
 	return []prometheus.Collector{o.consensus}
-}
-
-// HeimdallMilestoneVoteObserver tracks milestone votes from vote extensions.
-type HeimdallMilestoneVoteObserver struct {
-	proposed        *prometheus.CounterVec
-	missed          *prometheus.CounterVec
-	signedButMissed *prometheus.CounterVec
-	votingPower     *prometheus.GaugeVec
-}
-
-func (o *HeimdallMilestoneVoteObserver) Register(eb *EventBus) {
-	eb.Subscribe(topics.MilestoneVote, o)
-
-	o.proposed = metrics.NewCounter(
-		metrics.Heimdall,
-		"milestone_vote_proposed",
-		"Validators who proposed milestone in vote extension",
-		"validator_id", "signer_address",
-	)
-
-	o.missed = metrics.NewCounter(
-		metrics.Heimdall,
-		"milestone_vote_missed",
-		"Validators who didn't propose milestone",
-		"validator_id", "signer_address",
-	)
-
-	o.signedButMissed = metrics.NewCounter(
-		metrics.Heimdall,
-		"milestone_signed_but_missed",
-		"Validators who signed consensus but didn't propose milestone",
-		"validator_id", "signer_address",
-	)
-
-	o.votingPower = metrics.NewGauge(
-		metrics.Heimdall,
-		"milestone_voting_power",
-		"Percentage of voting power that proposed milestone",
-	)
-}
-
-func (o *HeimdallMilestoneVoteObserver) Notify(ctx context.Context, m Message) {
-	logger := NewLogger(o, m)
-	votes := m.Data().(*HeimdallMilestoneVotes)
-	network := m.Network().GetName()
-	provider := m.Provider()
-
-	var vpPct float64
-	if votes.TotalVotingPower > 0 {
-		vpPct = float64(votes.MilestoneVotingPower) / float64(votes.TotalVotingPower) * 100
-	}
-	o.votingPower.WithLabelValues(network, provider).Set(vpPct)
-
-	for _, vote := range votes.Votes {
-		id := strconv.FormatUint(vote.ValidatorID, 10)
-		switch {
-		case vote.HasMilestone:
-			o.proposed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
-		case vote.BlockIDFlag == heimdall.BlockIDFlagCommit:
-			// Signed consensus but didn't propose milestone
-			o.signedButMissed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
-			o.missed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
-		default:
-			// Absent/nil - didn't sign consensus and no milestone
-			o.missed.WithLabelValues(network, provider, id, vote.ValidatorAddress).Inc()
-		}
-	}
-
-	missed := votes.TotalValidators - votes.MilestoneVoters
-	if missed > 0 {
-		logger.Trace().
-			Uint64("height", votes.Height).
-			Int("total_validators", votes.TotalValidators).
-			Int("milestone_voters", votes.MilestoneVoters).
-			Int("missed", missed).
-			Msg("Detected validators without milestone vote")
-	}
-}
-
-func (o *HeimdallMilestoneVoteObserver) GetCollectors() []prometheus.Collector {
-	return []prometheus.Collector{o.proposed, o.missed, o.signedButMissed, o.votingPower}
 }

--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -261,6 +261,7 @@ type MilestoneObserver struct {
 	startBlock *prometheus.GaugeVec
 	endBlock   *prometheus.GaugeVec
 	observed   *prometheus.CounterVec
+	proposed   *prometheus.CounterVec
 	blockRange *prometheus.HistogramVec
 
 	// Vote metrics (merged from HeimdallMilestoneVoteObserver)
@@ -284,6 +285,7 @@ func (o *MilestoneObserver) Notify(ctx context.Context, m Message) {
 	o.endBlock.WithLabelValues(network, provider).Set(float64(milestone.EndBlock))
 
 	o.observed.WithLabelValues(network, provider).Inc()
+	o.proposed.WithLabelValues(network, provider, milestone.Proposer).Inc()
 	o.blockRange.WithLabelValues(network, provider).Observe(float64(milestone.EndBlock - milestone.StartBlock))
 
 	// Process vote metrics if votes are attached
@@ -332,6 +334,7 @@ func (o *MilestoneObserver) Register(eb *EventBus) {
 	o.startBlock = metrics.NewGauge(metrics.Heimdall, "milestone_start_block", "The milestone start block")
 	o.endBlock = metrics.NewGauge(metrics.Heimdall, "milestone_end_block", "The milestone end block")
 	o.observed = metrics.NewCounter(metrics.Heimdall, "milestone_observed", "The number of milestones observed")
+	o.proposed = metrics.NewCounter(metrics.Heimdall, "milestone_proposed", "Milestones proposed by validator", "proposer")
 	o.blockRange = metrics.NewHistogram(
 		metrics.Heimdall,
 		"milestone_block_range",
@@ -376,6 +379,7 @@ func (o *MilestoneObserver) GetCollectors() []prometheus.Collector {
 		o.startBlock,
 		o.endBlock,
 		o.observed,
+		o.proposed,
 		o.blockRange,
 		o.voteProposed,
 		o.voteMissed,

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -161,7 +161,6 @@ var observersMap = map[string]Observer{
 	"heimdall_missed_block_proposal":      new(HeimdallMissedBlockProposalObserver),
 	"heimdall_missed_checkpoint_proposal": new(HeimdallMissedCheckpointProposalObserver),
 	"heimdall_missed_vote":                new(HeimdallMissedVoteObserver),
-	"heimdall_milestone_vote":             new(HeimdallMilestoneVoteObserver),
 	"heimdall_signature_count":            new(HeimdallSignatureCountObserver),
 	"heimdall_validator_set_change":       new(HeimdallValidatorSetChangeObserver),
 	"milestone":                           new(MilestoneObserver),

--- a/observer/topics/observabletopic_string.go
+++ b/observer/topics/observabletopic_string.go
@@ -50,14 +50,13 @@ func _() {
 	_ = x[ValidatorWallet-39]
 	_ = x[ValidatorSet-40]
 	_ = x[MissedVote-41]
-	_ = x[MilestoneVote-42]
-	_ = x[ZkEVMBatches-43]
-	_ = x[StakingEvents-44]
+	_ = x[ZkEVMBatches-42]
+	_ = x[StakingEvents-43]
 }
 
-const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerSPOLControllerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteMilestoneVoteZkEVMBatchesStakingEvents"
+const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerSPOLControllerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteZkEVMBatchesStakingEvents"
 
-var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 450, 461, 467, 482, 492, 507, 519, 534, 546, 556, 569, 581, 594}
+var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 450, 461, 467, 482, 492, 507, 519, 534, 546, 556, 568, 581}
 
 func (i ObservableTopic) String() string {
 	idx := int(i) - 0

--- a/observer/topics/topics.go
+++ b/observer/topics/topics.go
@@ -46,7 +46,6 @@ const (
 	ValidatorWallet                                    // observer.ValidatorWalletBalances
 	ValidatorSet                                       // *observer.HeimdallValidatorSets
 	MissedVote                                         // *observer.HeimdallMissedVotes
-	MilestoneVote                                      // *observer.HeimdallMilestoneVotes
 	ZkEVMBatches                                       // observer.ZkEVMBatches
 	StakingEvents                                      // *observer.StakingEvents
 )

--- a/provider/heimdall.go
+++ b/provider/heimdall.go
@@ -55,7 +55,6 @@ type HeimdallProvider struct {
 	validatorSets *observer.HeimdallValidatorSets
 
 	missedVotes    []*observer.HeimdallMissedVotes
-	milestoneVotes []*observer.HeimdallMilestoneVotes
 	validatorIDMap map[string]uint64 // normalized signer_address -> val_id
 
 	refreshStateTime *time.Duration
@@ -90,14 +89,13 @@ func (h *HeimdallProvider) RefreshState(ctx context.Context) error {
 	h.logger.Debug().Msg("Refreshing Heimdall state")
 
 	h.refreshBlockBuffer()
+	h.refreshValidatorSet()
 	h.refreshMilestone()
 	h.refreshCheckpoint()
 	h.refreshMissedCheckpointProposal()
 	h.refreshMissedBlockProposal()
 	h.refreshSpan()
-	h.refreshValidatorSet()
 	h.refreshMissedVotes()
-	h.refreshMilestoneVotes()
 
 	return nil
 }
@@ -183,11 +181,6 @@ func (h *HeimdallProvider) PublishEvents(ctx context.Context) error {
 			m := observer.NewMessage(h.network, h.label, mv)
 			h.bus.Publish(ctx, topics.MissedVote, m)
 		}
-	}
-
-	for _, mv := range h.milestoneVotes {
-		m := observer.NewMessage(h.network, h.label, mv)
-		h.bus.Publish(ctx, topics.MilestoneVote, m)
 	}
 
 	h.bus.Publish(ctx, topics.RefreshStateTime, observer.NewMessage(h.network, h.label, h.refreshStateTime))
@@ -346,6 +339,10 @@ func (h *HeimdallProvider) refreshMilestone() error {
 
 		milestone := &v2.Milestone
 		milestone.Count = i
+
+		// Find and attach votes for this milestone
+		milestone.Votes = h.findMilestoneVotes(milestone)
+
 		h.milestones = append(h.milestones, milestone)
 	}
 
@@ -757,21 +754,83 @@ func (h *HeimdallProvider) getMilestoneFromVoteExtension(vote *observer.Heimdall
 	vote.MilestoneEnd = mp.StartBlockNumber + uint64(len(mp.BlockHashes)) - 1
 }
 
-func (h *HeimdallProvider) refreshMilestoneVotes() {
-	if h.validatorIDMap == nil {
-		return
+// getBlockHeight estimates the Heimdall block height for a given timestamp.
+// Assumes ~2 second block time.
+func (h *HeimdallProvider) getBlockHeight(target int64) uint64 {
+	if h.blockNumber == 0 {
+		return 0
 	}
 
-	h.milestoneVotes = nil
+	block := h.getBlock(0)
+	if block == nil {
+		return 0
+	}
 
-	h.logger.Debug().Msg("Refreshing milestone votes")
+	curr, err := block.Time()
+	if err != nil {
+		return 0
+	}
 
-	for height := h.prevBlockNumber + 1; height <= h.blockNumber && h.prevBlockNumber != 0; height++ {
-		mv, err := h.getMilestoneVotes(height)
+	// Estimate based on ~2 second block time
+	diff := (int64(curr) - target) / 2
+	if diff < 0 {
+		return 0
+	}
+
+	if uint64(diff) > h.blockNumber {
+		return 0
+	}
+
+	return h.blockNumber - uint64(diff)
+}
+
+// findMilestoneVotes searches for votes matching this milestone's range.
+// Uses the milestone timestamp to estimate the finalization block.
+// Returns the first matching vote block, or nil if not found.
+func (h *HeimdallProvider) findMilestoneVotes(milestone *observer.HeimdallMilestone) *observer.HeimdallMilestoneVotes {
+	if h.validatorIDMap == nil {
+		return nil
+	}
+
+	height := h.getBlockHeight(milestone.Timestamp)
+	if height == 0 {
+		return nil
+	}
+
+	// Search a small window around the estimated height
+	const window = 5
+	start := max(1, height-window)
+	end := min(h.blockNumber, height+window)
+
+	for i := start; i <= end; i++ {
+		mv, err := h.getMilestoneVotes(i)
 		if err != nil {
-			h.logger.Warn().Err(err).Uint64("height", height).Msg("Failed to detect milestone votes")
 			continue
 		}
-		h.milestoneVotes = append(h.milestoneVotes, mv)
+
+		if mv.MilestoneVoters == 0 {
+			continue
+		}
+
+		if h.votesMatchMilestone(mv, milestone) {
+			return mv
+		}
 	}
+
+	return nil
+}
+
+// votesMatchMilestone checks if any vote in the votes matches the milestone's block range.
+func (h *HeimdallProvider) votesMatchMilestone(mv *observer.HeimdallMilestoneVotes, milestone *observer.HeimdallMilestone) bool {
+	for _, vote := range mv.Votes {
+		if !vote.HasMilestone {
+			continue
+		}
+
+		if vote.MilestoneStart == milestone.StartBlock && vote.MilestoneEnd == milestone.EndBlock {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Simplifies milestone vote tracking by using the milestone timestamp to find the finalization block directly.

**Problem:** Finding matching vote blocks was unreliable because we searched a fixed 100-block window backward from the current block, which could miss the actual finalization block.

**Solution:** Use the milestone's `Timestamp` field to estimate the Heimdall block height where it was finalized:
```
blockHeight ≈ currentBlockHeight - (currentTimestamp - milestoneTimestamp) / blockTime
```
Then search a small ±5 block window around that estimate.

**Changes:**
- Add `estimateBlockHeight()` helper to convert timestamp to block height (~2s block time)
- Simplify `findMilestoneVotes()` to use timestamp-based estimation
- Merge vote metrics into `MilestoneObserver` (remove separate `MilestoneVote` topic)
- Votes are now attached directly to milestones during refresh

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [x] `go test ./...` passes
- [x] Run locally with `dotenv run go run cmd/main.go config.dev.yml`
- [x] After ~1 minute, verify metrics: `curl -s localhost:9090/metrics | grep milestone`
- [x] Confirm `proposed + missed == milestones_observed` (gap should be 0-1 at most)