### PR TITLE
fix(sensor): bound fillRange so a Datastore timeout can't hot-loop

### DIFF
--- a/provider/sensor.go
+++ b/provider/sensor.go
@@ -25,6 +25,12 @@ import (
 	"github.com/0xPolygon/panoptichain/observer/topics"
 )
 
+// blockBufferSize is the maximum number of blocks kept in the provider's block
+// buffer. It also bounds how far back a single poll will backfill: there is no
+// point querying more blocks than the buffer can hold, since the oldest are
+// evicted immediately anyway.
+const blockBufferSize = 512
+
 type SensorNetworkProvider struct {
 	network  network.Network
 	label    string
@@ -166,10 +172,37 @@ func (s *SensorNetworkProvider) refreshBlockBuffer(ctx context.Context) error {
 		Msg("Refreshing sensor network block state")
 
 	if s.prevBlockNumber != 0 && s.prevBlockNumber != s.blockNumber {
-		s.fillRange(ctx, s.prevBlockNumber)
+		s.fillRange(ctx, s.clampStart(s.prevBlockNumber))
 	}
 
 	return nil
+}
+
+// clampStart bounds the backfill start block so we never issue a Datastore range
+// query spanning a huge gap. After a freeze and recovery (e.g. the sensor node
+// is restarted), blockNumber can jump far ahead of the previous value; querying
+// that entire mostly-empty range is expensive and was a factor in turning a node
+// blip into a prolonged outage. We clamp to at most blockBufferSize blocks behind
+// the head (querying more is pointless since the buffer would evict them) and
+// log how many blocks are skipped so the gap stays visible.
+func (s *SensorNetworkProvider) clampStart(start uint64) uint64 {
+	if s.blockNumber <= blockBufferSize {
+		return start
+	}
+
+	minStart := s.blockNumber - blockBufferSize
+	if minStart <= start {
+		return start
+	}
+
+	s.logger.Warn().
+		Uint64("prev_block_number", s.prevBlockNumber).
+		Uint64("block_number", s.blockNumber).
+		Uint64("skipped_blocks", minStart-start).
+		Uint64("block_buffer_size", blockBufferSize).
+		Msg("Block gap exceeds buffer size; clamping sensor backfill range")
+
+	return minStart
 }
 
 func (s *SensorNetworkProvider) fillRange(ctx context.Context, start uint64) {
@@ -199,8 +232,13 @@ func (s *SensorNetworkProvider) fillRange(ctx context.Context, start uint64) {
 			break
 		}
 		if err != nil {
+			// A Datastore iterator error is terminal: subsequent calls to
+			// iter.Next return the same error. Break instead of continuing (as
+			// rpc.go and heimdall.go do on a fetch error) so a failing query
+			// can't spin into an unbounded hot loop that floods logs and wedges
+			// the provider goroutine.
 			s.logger.Warn().Err(err).Msg("Failed to get next block")
-			continue
+			break
 		}
 
 		wg.Go(func() {
@@ -215,7 +253,7 @@ func (s *SensorNetworkProvider) fillRange(ctx context.Context, start uint64) {
 
 		// Only keep a certain amount of blocks in the buffer. Remove the oldest
 		// block if it is full.
-		if s.blocks.Len() >= 512 {
+		if s.blocks.Len() >= blockBufferSize {
 			s.blocks.Remove(s.blocks.Front())
 		}
 

--- a/provider/sensor_test.go
+++ b/provider/sensor_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import "testing"
+
+// newSensorProvider creates a SensorNetworkProvider with the block-tracking
+// fields set, suitable for exercising the pure range-clamping logic.
+func newSensorProvider(prev, curr uint64) *SensorNetworkProvider {
+	return &SensorNetworkProvider{
+		prevBlockNumber: prev,
+		blockNumber:     curr,
+		logger:          NewLogger(nil, "test"),
+	}
+}
+
+func TestClampStart(t *testing.T) {
+	tests := []struct {
+		name  string
+		prev  uint64
+		curr  uint64
+		start uint64
+		want  uint64
+	}{
+		{
+			name:  "small gap within buffer size is unchanged",
+			prev:  blockBufferSize + 1000,
+			curr:  blockBufferSize + 1003,
+			start: blockBufferSize + 1000,
+			want:  blockBufferSize + 1000,
+		},
+		{
+			name:  "large gap is clamped to head minus buffer size",
+			prev:  1000,
+			curr:  500000,
+			start: 1000,
+			want:  500000 - blockBufferSize,
+		},
+		{
+			name:  "head below buffer size never underflows",
+			prev:  5,
+			curr:  blockBufferSize - 100,
+			start: 5,
+			want:  5,
+		},
+		{
+			name:  "exactly at threshold is unchanged",
+			prev:  1000,
+			curr:  1000 + blockBufferSize,
+			start: 1000,
+			want:  1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSensorProvider(tt.prev, tt.curr)
+			got := s.clampStart(tt.start)
+			if got != tt.want {
+				t.Errorf("clampStart(%d) = %d, want %d", tt.start, got, tt.want)
+			}
+
+			// The clamped start must never produce an out-of-range query: it
+			// stays within [start, blockNumber] and within blockBufferSize of head.
+			if got > tt.curr {
+				t.Errorf("clampStart(%d) = %d exceeds head %d", tt.start, got, tt.curr)
+			}
+			if tt.curr > blockBufferSize && tt.curr-got > blockBufferSize {
+				t.Errorf("clampStart(%d) = %d is more than %d behind head %d",
+					tt.start, got, blockBufferSize, tt.curr)
+			}
+		})
+	}
+}


### PR DESCRIPTION

# Description

When iter.Next() returned a non-Done error (a Datastore DeadlineExceeded), fillRange did `continue` with no break, backoff, or cap, and ctx is context.Background() so there was no deadline to abort it. A terminal iterator error therefore spun into an unbounded loop: it re-issued the same failing query forever, emitting one "Failed to get next block" warn per iteration.

On 2026-06-10 this turned a single transient Datastore latency spike on the shared `amoy` database into an ~8-hour stale-data outage and a ~100k logs/sec storm, in both dev and prod simultaneously (both read the same Datastore, so each instance's query flood kept the DB slow for the other).

- fillRange now breaks on a persistent iterator error, matching rpc.go and heimdall.go, so the provider goroutine returns to normal polling instead of wedging.
- Bound the backfill range to blockBufferSize blocks behind the head. After a freeze/recovery the head can jump far ahead of prevBlockNumber; querying more than the buffer can hold is wasted work (the oldest are evicted anyway). The 512 buffer cap is now a named constant used in both places, and a clamp logs how many blocks were skipped so gaps stay visible.


<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
