### PR TITLE
fix(checkpoint): count checkpoint signatures once per checkpoint

### DIFF
--- a/provider/rpc.go
+++ b/provider/rpc.go
@@ -36,22 +36,22 @@ import (
 
 // RPCProvider is the generic struct for all EVM style JSON RPC services.
 type RPCProvider struct {
-	url              string
-	network          network.Network
-	label            string
-	bus              *observer.EventBus
-	interval         time.Duration
-	logger           zerolog.Logger
-	blockNumber      uint64
-	prevBlockNumber  uint64
-	finalizedHeight  uint64
-	blockBuffer      *blockbuffer.BlockBuffer
-	txPool           *observer.TransactionPool
-	refreshStateTime *time.Duration
-	contracts        config.Contracts
-	timeToMine       *config.TimeToMine
-	accounts         []config.Account
-	accountBalances  observer.AccountBalances
+	url                    string
+	network                network.Network
+	label                  string
+	bus                    *observer.EventBus
+	interval               time.Duration
+	logger                 zerolog.Logger
+	blockNumber            uint64
+	prevBlockNumber        uint64
+	finalizedHeight        uint64
+	blockBuffer            *blockbuffer.BlockBuffer
+	txPool                 *observer.TransactionPool
+	refreshStateTime       *time.Duration
+	contracts              config.Contracts
+	timeToMine             *config.TimeToMine
+	accounts               []config.Account
+	accountBalances        observer.AccountBalances
 	accountTxs             observer.AccountTxs
 	timeToFinalized        *uint64
 	blockLookBack          uint64
@@ -62,12 +62,17 @@ type RPCProvider struct {
 	// PoS
 	stateSync            map[bool]*observer.StateSync
 	checkpointSignatures map[bool]*observer.CheckpointSignatures
-	validatorBalances    observer.ValidatorWalletBalances
-	missedBlockProposal  observer.MissedBlockProposal
-	stakeManager         *observer.StakeManager
-	sPOLController       *observer.SPOLController
-	stakingEvents        *observer.StakingEvents
-	stakingInfoAddress   *common.Address
+	// prevCheckpointID is the header block ID of the most recent checkpoint
+	// whose signatures were counted. Checkpoints are republished on every poll
+	// cycle, so this lets us mark republishes as seen and fire the counters
+	// once per checkpoint.
+	prevCheckpointID    *big.Int
+	validatorBalances   observer.ValidatorWalletBalances
+	missedBlockProposal observer.MissedBlockProposal
+	stakeManager        *observer.StakeManager
+	sPOLController      *observer.SPOLController
+	stakingEvents       *observer.StakingEvents
+	stakingInfoAddress  *common.Address
 
 	// zkEVM
 	batches        observer.ZkEVMBatches
@@ -700,8 +705,14 @@ func (r *RPCProvider) refreshCheckpoint(ctx context.Context, c *ethclient.Client
 		event = iter.Event
 	}
 
-	if event == nil {
-		r.logger.Debug().Msg("No NewHeaderBlock events found")
+	// A new checkpoint is not always present: between checkpoints the scan window
+	// contains no event, and the same checkpoint can be re-found before the next
+	// one arrives. In both cases there is nothing new to record, so skip the
+	// expensive block and transaction lookups below.
+	if r.seenCheckpoint(event) {
+		if event != nil {
+			r.refreshFinalizedCheckpoint(ctx, c)
+		}
 		return
 	}
 
@@ -761,16 +772,43 @@ func (r *RPCProvider) refreshCheckpoint(ctx context.Context, c *ethclient.Client
 
 	r.refreshFinalizedCheckpoint(ctx, c)
 
+	// This is a checkpoint we have not counted before (seenCheckpoint returned
+	// false above), so record its ID and store it unseen for the observer to
+	// count.
 	finalized := false
-	cs := r.checkpointSignatures[finalized]
-	seen := cs != nil && event.HeaderBlockId.Cmp(cs.Event.HeaderBlockId) == 0
+	r.prevCheckpointID = new(big.Int).Set(event.HeaderBlockId)
 	r.checkpointSignatures[finalized] = &observer.CheckpointSignatures{
 		Event:     event,
 		Block:     block,
 		Signers:   signers,
-		Seen:      seen,
+		Seen:      false,
 		Finalized: finalized,
 	}
+}
+
+// seenCheckpoint reports whether the latest observed checkpoint has already been
+// counted. event is the latest NewHeaderBlock event in the scan window, or nil
+// if none was found. A checkpoint is new when an event is present whose header
+// block ID differs from the last one we recorded; in that case the caller must
+// fetch its signatures and store it.
+//
+// Checkpoints are republished on every poll cycle, so when the checkpoint has
+// already been counted — no new event, or the same header block ID — this marks
+// the stored entry seen so the observer does not re-count its signatures. The
+// entry is replaced with a fresh copy rather than mutated because the previous
+// pointer may still be in flight in an observer goroutine.
+func (r *RPCProvider) seenCheckpoint(event *contracts.RootChainNewHeaderBlock) bool {
+	if event != nil && (r.prevCheckpointID == nil || event.HeaderBlockId.Cmp(r.prevCheckpointID) != 0) {
+		return false
+	}
+
+	if prev := r.checkpointSignatures[false]; prev != nil && !prev.Seen {
+		cp := *prev
+		cp.Seen = true
+		r.checkpointSignatures[false] = &cp
+	}
+
+	return true
 }
 
 func (r *RPCProvider) refreshFinalizedCheckpoint(ctx context.Context, c *ethclient.Client) {

--- a/provider/rpc_test.go
+++ b/provider/rpc_test.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xPolygon/panoptichain/contracts"
+	"github.com/0xPolygon/panoptichain/observer"
+)
+
+// newHeaderBlock builds a NewHeaderBlock event with the given header block ID.
+func newHeaderBlock(id int64) *contracts.RootChainNewHeaderBlock {
+	return &contracts.RootChainNewHeaderBlock{HeaderBlockId: big.NewInt(id)}
+}
+
+// runCheckpointCycle simulates one poll cycle of refreshCheckpoint's dedup
+// logic: seenCheckpoint decides whether the checkpoint is new, and the new path
+// records it unseen (mirroring the store at the end of refreshCheckpoint, minus
+// the RPC lookups). It returns whether this cycle would have published a
+// countable checkpoint (Seen == false), which is what the observer increments
+// its counters on.
+func runCheckpointCycle(r *RPCProvider, event *contracts.RootChainNewHeaderBlock) bool {
+	if !r.seenCheckpoint(event) {
+		r.prevCheckpointID = new(big.Int).Set(event.HeaderBlockId)
+		r.checkpointSignatures[false] = &observer.CheckpointSignatures{
+			Event: event,
+			Seen:  false,
+		}
+	}
+	return !r.checkpointSignatures[false].Seen
+}
+
+func newCheckpointProvider() *RPCProvider {
+	return &RPCProvider{
+		checkpointSignatures: make(map[bool]*observer.CheckpointSignatures),
+		logger:               NewLogger(nil, "test"),
+	}
+}
+
+// TestSeenCheckpoint_CountsOncePerCheckpoint is the regression test for the
+// over-counting bug: a checkpoint is republished on every poll cycle, but its
+// signatures must only be counted once. Each cycle produces a countable
+// (unseen) entry only when a genuinely new checkpoint is detected.
+func TestSeenCheckpoint_CountsOncePerCheckpoint(t *testing.T) {
+	a, b := newHeaderBlock(100), newHeaderBlock(200)
+
+	// A realistic sequence: checkpoint A appears, then several idle polls with
+	// no event in the scan window, then a new checkpoint B, then B is re-found
+	// once at a scan-window boundary before going idle again.
+	cycles := []*contracts.RootChainNewHeaderBlock{
+		a,   // new checkpoint A detected
+		nil, // idle poll, A republished
+		nil, // idle poll, A republished
+		nil, // idle poll, A republished
+		b,   // new checkpoint B detected
+		b,   // B re-found in an overlapping window
+		nil, // idle poll, B republished
+	}
+
+	r := newCheckpointProvider()
+	countable := 0
+	for i, event := range cycles {
+		if runCheckpointCycle(r, event) {
+			countable++
+			t.Logf("cycle %d: countable checkpoint published", i)
+		}
+	}
+
+	// Only the two distinct checkpoints (A and B) should ever be counted.
+	if countable != 2 {
+		t.Fatalf("expected 2 countable checkpoints, got %d", countable)
+	}
+}
+
+func TestSeenCheckpoint(t *testing.T) {
+	tests := []struct {
+		name           string
+		prevID         *big.Int
+		stored         *observer.CheckpointSignatures
+		event          *contracts.RootChainNewHeaderBlock
+		wantSeen       bool // return value
+		wantStoredSeen bool // Seen of the stored entry after the call
+		hasStored      bool
+	}{
+		{
+			name:     "new checkpoint with no prior state is not seen",
+			event:    newHeaderBlock(100),
+			wantSeen: false,
+		},
+		{
+			name:     "new checkpoint id is not seen",
+			prevID:   big.NewInt(100),
+			event:    newHeaderBlock(200),
+			wantSeen: false,
+		},
+		{
+			name:           "same checkpoint id is seen and the unseen entry is flipped",
+			prevID:         big.NewInt(100),
+			stored:         &observer.CheckpointSignatures{Event: newHeaderBlock(100), Seen: false},
+			event:          newHeaderBlock(100),
+			wantSeen:       true,
+			wantStoredSeen: true,
+			hasStored:      true,
+		},
+		{
+			name:           "no event republishes the last checkpoint as seen",
+			prevID:         big.NewInt(100),
+			stored:         &observer.CheckpointSignatures{Event: newHeaderBlock(100), Seen: false},
+			event:          nil,
+			wantSeen:       true,
+			wantStoredSeen: true,
+			hasStored:      true,
+		},
+		{
+			name:           "already seen entry stays seen",
+			prevID:         big.NewInt(100),
+			stored:         &observer.CheckpointSignatures{Event: newHeaderBlock(100), Seen: true},
+			event:          nil,
+			wantSeen:       true,
+			wantStoredSeen: true,
+			hasStored:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newCheckpointProvider()
+			r.prevCheckpointID = tt.prevID
+			if tt.hasStored {
+				r.checkpointSignatures[false] = tt.stored
+			}
+
+			got := r.seenCheckpoint(tt.event)
+			if got != tt.wantSeen {
+				t.Errorf("seenCheckpoint() = %v, want %v", got, tt.wantSeen)
+			}
+
+			if tt.hasStored {
+				if seen := r.checkpointSignatures[false].Seen; seen != tt.wantStoredSeen {
+					t.Errorf("stored entry Seen = %v, want %v", seen, tt.wantStoredSeen)
+				}
+			}
+		})
+	}
+}
+
+// TestSeenCheckpoint_FreshCopy verifies that marking the stored entry seen does
+// not mutate the previously published pointer, which may still be in flight in
+// an observer goroutine.
+func TestSeenCheckpoint_FreshCopy(t *testing.T) {
+	r := newCheckpointProvider()
+	r.prevCheckpointID = big.NewInt(100)
+	published := &observer.CheckpointSignatures{Event: newHeaderBlock(100), Seen: false}
+	r.checkpointSignatures[false] = published
+
+	r.seenCheckpoint(nil)
+
+	if published.Seen {
+		t.Error("previously published entry was mutated in place")
+	}
+	if !r.checkpointSignatures[false].Seen {
+		t.Error("stored entry was not marked seen")
+	}
+}


### PR DESCRIPTION

# Description

Checkpoint signatures are republished on every poll cycle, but refreshCheckpoint only scanned the newest block window and returned early when it found no NewHeaderBlock event. Between checkpoints that left the stored entry at Seen=false, so the observer re-incremented missed_checkpoint_signature (and signed_checkpoint) every poll until the next checkpoint, inflating the counters by roughly the checkpoint-interval / poll-interval ratio.

Track the last counted checkpoint via prevCheckpointID and, on the not-new path, mark the stored entry seen (as a fresh copy, since the previous pointer may still be in flight in an observer goroutine) so it is no longer counted on republish. The not-new path also skips the block/transaction lookups and signature recovery it no longer needs.

Add provider/rpc_test.go covering the dedup state machine across poll cycles, including the once-per-checkpoint regression.


<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration. -->

- [ ] Test A
- [ ] Test B
