### PR TITLE
fix(heimdall): keep milestone freshness accurate under Heimdall v2 load

### DIFF
--- a/api/json.go
+++ b/api/json.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,19 +23,47 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d %s", e.StatusCode, e.Status)
 }
 
-// GetJSON fetches JSON data from the specified URL and decodes it into the
-// target variable.
-func GetJSON(url string, target any) error {
-	client := &http.Client{Timeout: 10 * time.Second}
+// sharedClient is a single, pooled HTTP client reused across all requests.
+// Providers hit the same hosts (e.g. the Heimdall/Tendermint APIs) many times
+// per refresh cycle, so keeping connections alive avoids re-dialing on every
+// call. The per-request Timeout is kept as a hard ceiling even when a caller's
+// context grants a longer deadline.
+var sharedClient = newSharedClient()
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func newSharedClient() *http.Client {
+	// Clone the default transport so we inherit proxy, TLS, and HTTP/2
+	// defaults, then raise the idle-connection pool limits (the default
+	// MaxIdleConnsPerHost of 2 would defeat pooling for our per-host bursts).
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+}
+
+// HTTPClient returns the shared, pooled HTTP client. Callers that need to issue
+// requests GetJSON does not cover (e.g. POSTs) should use this so they share
+// the same connection pool.
+func HTTPClient() *http.Client {
+	return sharedClient
+}
+
+// GetJSON fetches JSON data from the specified URL and decodes it into the
+// target variable. The request is bound to ctx, so cancelling or expiring the
+// context aborts an in-flight request.
+func GetJSON(ctx context.Context, url string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Cache-Control", "no-cache, no-store")
 	req.Header.Set("Pragma", "no-cache")
 
-	r, err := client.Do(req)
+	r, err := sharedClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/json_test.go
+++ b/api/json_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +21,7 @@ func TestGetJSON_Success(t *testing.T) {
 		Value int    `json:"value"`
 	}
 
-	err := GetJSON(server.URL, &result)
+	err := GetJSON(context.Background(), server.URL, &result)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestGetJSON_HTTPError(t *testing.T) {
 			defer server.Close()
 
 			var result struct{}
-			err := GetJSON(server.URL, &result)
+			err := GetJSON(context.Background(), server.URL, &result)
 
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -100,7 +101,7 @@ func TestGetJSON_HTTPError(t *testing.T) {
 func TestGetJSON_NetworkError(t *testing.T) {
 	// Use an invalid URL to simulate a network error
 	var result struct{}
-	err := GetJSON("http://localhost:1", &result)
+	err := GetJSON(context.Background(), "http://localhost:1", &result)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")

--- a/api/validator.go
+++ b/api/validator.go
@@ -106,9 +106,10 @@ func GetValidators(basePath string) ([]Validator, error) {
 	}
 
 	var body ValidatorSet
-	// TODO: thread the caller's context here (wave 2). This validator set is
-	// cached for an hour, so it rarely hits the network; use a background
-	// context as a documented seam until callers are made context-aware.
+	// This validator set is cached for an hour, so it rarely hits the network.
+	// A background context is used as a deliberate seam: the callers of
+	// GetValidators are not yet context-aware, so there is no caller context to
+	// thread through here.
 	if err := GetJSON(context.Background(), path, &body); err != nil {
 		return nil, err
 	}

--- a/api/validator.go
+++ b/api/validator.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"sync"
@@ -105,7 +106,10 @@ func GetValidators(basePath string) ([]Validator, error) {
 	}
 
 	var body ValidatorSet
-	if err := GetJSON(path, &body); err != nil {
+	// TODO: thread the caller's context here (wave 2). This validator set is
+	// cached for an hour, so it rarely hits the network; use a background
+	// context as a documented seam until callers are made context-aware.
+	if err := GetJSON(context.Background(), path, &body); err != nil {
 		return nil, err
 	}
 

--- a/metrics.md
+++ b/metrics.md
@@ -663,6 +663,15 @@ Variable Labels:
 - network
 - provider
 
+### panoptichain_heimdall_milestone_skipped
+The number of milestones skipped during catch-up
+
+Metric Type: CounterVec
+
+Variable Labels:
+- network
+- provider
+
 ### panoptichain_heimdall_milestone_observed
 The number of milestones observed
 

--- a/observer/heimdall.go
+++ b/observer/heimdall.go
@@ -255,11 +255,22 @@ type HeimdallMilestoneV2 struct {
 	Milestone HeimdallMilestone `json:"milestone"`
 }
 
+// HeimdallLatestMilestone carries the current tip milestone. It is published
+// every cycle (independent of the per-milestone backlog stream) so the
+// freshness gauges reflect the true latest milestone and can never lag behind a
+// slow catch-up. Skipped is the number of milestones dropped this cycle by the
+// catch-up cap.
+type HeimdallLatestMilestone struct {
+	*HeimdallMilestone
+	Skipped int64
+}
+
 type MilestoneObserver struct {
 	time       *prometheus.GaugeVec
 	count      *prometheus.GaugeVec
 	startBlock *prometheus.GaugeVec
 	endBlock   *prometheus.GaugeVec
+	skipped    *prometheus.CounterVec
 	observed   *prometheus.CounterVec
 	proposed   *prometheus.CounterVec
 	blockRange *prometheus.HistogramVec
@@ -272,17 +283,31 @@ type MilestoneObserver struct {
 }
 
 func (o *MilestoneObserver) Notify(ctx context.Context, m Message) {
-	logger := NewLogger(o, m)
-	milestone := m.Data().(*HeimdallMilestone)
 	network := m.Network().GetName()
 	provider := m.Provider()
 
-	seconds := time.Since(time.Unix(milestone.Timestamp, 0)).Seconds()
+	// The tip milestone drives the freshness gauges. It is published every
+	// cycle before the backlog is drained, so these gauges always reflect the
+	// latest milestone and never lag behind a slow catch-up.
+	if latest, ok := m.Data().(*HeimdallLatestMilestone); ok {
+		if latest.HeimdallMilestone == nil {
+			return
+		}
+		seconds := time.Since(time.Unix(latest.Timestamp, 0)).Seconds()
+		o.time.WithLabelValues(network, provider).Set(seconds)
+		o.count.WithLabelValues(network, provider).Set(float64(latest.Count))
+		o.startBlock.WithLabelValues(network, provider).Set(float64(latest.StartBlock))
+		o.endBlock.WithLabelValues(network, provider).Set(float64(latest.EndBlock))
+		if latest.Skipped > 0 {
+			o.skipped.WithLabelValues(network, provider).Add(float64(latest.Skipped))
+		}
+		return
+	}
 
-	o.count.WithLabelValues(network, provider).Set(float64(milestone.Count))
-	o.time.WithLabelValues(network, provider).Set(float64(seconds))
-	o.startBlock.WithLabelValues(network, provider).Set(float64(milestone.StartBlock))
-	o.endBlock.WithLabelValues(network, provider).Set(float64(milestone.EndBlock))
+	// The per-milestone stream drives count/vote accounting. It gaps during
+	// catch-up (see refreshMilestone), which is acceptable.
+	logger := NewLogger(o, m)
+	milestone := m.Data().(*HeimdallMilestone)
 
 	o.observed.WithLabelValues(network, provider).Inc()
 	o.proposed.WithLabelValues(network, provider, milestone.Proposer).Inc()
@@ -328,11 +353,13 @@ func (o *MilestoneObserver) Notify(ctx context.Context, m Message) {
 
 func (o *MilestoneObserver) Register(eb *EventBus) {
 	eb.Subscribe(topics.Milestone, o)
+	eb.Subscribe(topics.MilestoneLatest, o)
 
 	o.time = metrics.NewGauge(metrics.Heimdall, "time_since_last_milestone", "The time since last milestone")
 	o.count = metrics.NewGauge(metrics.Heimdall, "milestone_count", "The milestone count")
 	o.startBlock = metrics.NewGauge(metrics.Heimdall, "milestone_start_block", "The milestone start block")
 	o.endBlock = metrics.NewGauge(metrics.Heimdall, "milestone_end_block", "The milestone end block")
+	o.skipped = metrics.NewCounter(metrics.Heimdall, "milestone_skipped", "The number of milestones skipped during catch-up")
 	o.observed = metrics.NewCounter(metrics.Heimdall, "milestone_observed", "The number of milestones observed")
 	o.proposed = metrics.NewCounter(metrics.Heimdall, "milestone_proposed", "Milestones proposed by validator", "proposer")
 	o.blockRange = metrics.NewHistogram(
@@ -378,6 +405,7 @@ func (o *MilestoneObserver) GetCollectors() []prometheus.Collector {
 		o.count,
 		o.startBlock,
 		o.endBlock,
+		o.skipped,
 		o.observed,
 		o.proposed,
 		o.blockRange,

--- a/observer/topics/observabletopic_string.go
+++ b/observer/topics/observabletopic_string.go
@@ -53,11 +53,12 @@ func _() {
 	_ = x[ZkEVMBatches-42]
 	_ = x[StakingEvents-43]
 	_ = x[BufferedCheckpoint-44]
+	_ = x[MilestoneLatest-45]
 }
 
-const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerSPOLControllerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteZkEVMBatchesStakingEventsBufferedCheckpoint"
+const _ObservableTopic_name = "AccountBalancesAccountTxsAggchainEventBlockIntervalBorMissedBlockProposalBorStateSyncBridgeEventBridgeEventTimesCheckpointCheckpointSignaturesClaimEventClaimEventTimesDepositCountsExchangeRateExitRootsFinalizedHeightGrafanaHashDivergenceHeimdallBlockIntervalHeimdallMissedBlockProposalMilestoneMissedCheckpointProposalNewEVMBlockNewHeimdallBlockProofRequestRefreshStateTimeReorgRollupManagerSensorBlockEventsSensorBlocksSpanStakeManagerSPOLControllerStolenBlockSystemTimeToFinalizedTimeToMineTransactionPoolTrustedBatchValidatorWalletValidatorSetMissedVoteZkEVMBatchesStakingEventsBufferedCheckpointMilestoneLatest"
 
-var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 450, 461, 467, 482, 492, 507, 519, 534, 546, 556, 568, 581, 599}
+var _ObservableTopic_index = [...]uint16{0, 15, 25, 38, 51, 73, 85, 96, 112, 122, 142, 152, 167, 180, 192, 201, 216, 223, 237, 258, 285, 294, 318, 329, 345, 357, 373, 378, 391, 408, 420, 424, 436, 450, 461, 467, 482, 492, 507, 519, 534, 546, 556, 568, 581, 599, 614}
 
 func (i ObservableTopic) String() string {
 	idx := int(i) - 0

--- a/observer/topics/topics.go
+++ b/observer/topics/topics.go
@@ -49,4 +49,5 @@ const (
 	ZkEVMBatches                                       // observer.ZkEVMBatches
 	StakingEvents                                      // *observer.StakingEvents
 	BufferedCheckpoint                                 // *observer.HeimdallCheckpoint (nil if no buffered checkpoint)
+	MilestoneLatest                                    // *observer.HeimdallLatestMilestone (tip milestone, drives freshness gauges)
 )

--- a/provider/exchange_rates.go
+++ b/provider/exchange_rates.go
@@ -48,17 +48,17 @@ func (e *ExchangeRatesProvider) RefreshState(ctx context.Context) error {
 
 	e.rates = nil
 	for base, quotes := range e.tokens {
-		e.fetchRates(base, quotes)
+		e.fetchRates(ctx, base, quotes)
 	}
 
 	return nil
 }
 
-func (e *ExchangeRatesProvider) fetchRates(base string, quotes []string) {
+func (e *ExchangeRatesProvider) fetchRates(ctx context.Context, base string, quotes []string) {
 	url := e.coinbaseURL + base
 
 	var body CoinbaseExchangeRates
-	if err := api.GetJSON(url, &body); err != nil {
+	if err := api.GetJSON(ctx, url, &body); err != nil {
 		e.logger.Error().Err(err).Str("url", url).Msg("Failed to fetch exchange rates")
 		return
 	}

--- a/provider/grafana.go
+++ b/provider/grafana.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0xPolygon/panoptichain/api"
 	"github.com/0xPolygon/panoptichain/config"
 	"github.com/0xPolygon/panoptichain/network"
 	"github.com/0xPolygon/panoptichain/observer"
@@ -36,19 +37,18 @@ func NewGrafanaProvider(n network.Network, eb *observer.EventBus, cfg config.Gra
 	}
 }
 
-func (g *GrafanaProvider) RefreshState(context.Context) error {
+func (g *GrafanaProvider) RefreshState(ctx context.Context) error {
 	defer timer(g.refreshStateTime)()
 
 	payload := []byte(`{"intervalMs":10000}`)
-	req, err := http.NewRequest("POST", g.url, bytes.NewBuffer(payload))
+	req, err := http.NewRequestWithContext(ctx, "POST", g.url, bytes.NewBuffer(payload))
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := api.HTTPClient().Do(req)
 	if err != nil {
 		return err
 	}

--- a/provider/heimdall.go
+++ b/provider/heimdall.go
@@ -49,6 +49,8 @@ type HeimdallProvider struct {
 
 	milestones         []*observer.HeimdallMilestone
 	prevMilestoneCount int64
+	latestMilestone    *observer.HeimdallMilestone
+	skippedMilestones  int64
 
 	spans *observer.HeimdallSpans
 
@@ -88,17 +90,24 @@ func NewHeimdallProvider(n network.Network, eb *observer.EventBus, cfg config.He
 func (h *HeimdallProvider) RefreshState(ctx context.Context) error {
 	defer timer(h.refreshStateTime)()
 
+	// Bound the whole cycle so a slow/degraded upstream can't make a single
+	// RefreshState run unbounded (api.GetJSON now honours this context). The
+	// freshness milestone is fetched first inside refreshMilestone, so a
+	// truncated cycle only drops backlog accounting, never the freshness gauge.
+	ctx, cancel := context.WithTimeout(ctx, h.refreshTimeout())
+	defer cancel()
+
 	h.logger.Debug().Msg("Refreshing Heimdall state")
 
-	h.refreshBlockBuffer()
+	h.refreshBlockBuffer(ctx)
 	h.refreshValidatorSet()
-	h.refreshMilestone()
-	h.refreshCheckpoint()
-	h.refreshBufferedCheckpoint()
-	h.refreshMissedCheckpointProposal()
-	h.refreshMissedBlockProposal()
-	h.refreshSpan()
-	h.refreshMissedVotes()
+	h.refreshMilestone(ctx)
+	h.refreshCheckpoint(ctx)
+	h.refreshBufferedCheckpoint(ctx)
+	h.refreshMissedCheckpointProposal(ctx)
+	h.refreshMissedBlockProposal(ctx)
+	h.refreshSpan(ctx)
+	h.refreshMissedVotes(ctx)
 
 	return nil
 }
@@ -164,6 +173,17 @@ func (h *HeimdallProvider) PublishEvents(ctx context.Context) error {
 		h.bus.Publish(ctx, topics.MissedCheckpointProposal, m)
 	}
 
+	// Publish the tip milestone (drives the freshness gauges) independently of
+	// the per-milestone backlog stream below, so freshness never lags a slow
+	// catch-up.
+	if h.latestMilestone != nil {
+		latest := observer.NewMessage(h.network, h.label, &observer.HeimdallLatestMilestone{
+			HeimdallMilestone: h.latestMilestone,
+			Skipped:           h.skippedMilestones,
+		})
+		h.bus.Publish(ctx, topics.MilestoneLatest, latest)
+	}
+
 	for _, milestone := range h.milestones {
 		m := observer.NewMessage(h.network, h.label, milestone)
 		h.bus.Publish(ctx, topics.Milestone, m)
@@ -198,9 +218,21 @@ func (h *HeimdallProvider) PollingInterval() time.Duration {
 	return h.interval
 }
 
-func (h *HeimdallProvider) refreshBlockBuffer() {
+// refreshTimeout bounds a single RefreshState cycle so a hung upstream cannot
+// stall the provider's loop indefinitely. Derived from the polling interval
+// with a floor; freshness is captured before the bounded work, so a truncated
+// cycle never affects the freshness gauges.
+func (h *HeimdallProvider) refreshTimeout() time.Duration {
+	const minTimeout = 30 * time.Second
+	if t := h.interval * 4; t > minTimeout {
+		return t
+	}
+	return minTimeout
+}
+
+func (h *HeimdallProvider) refreshBlockBuffer(ctx context.Context) {
 	h.prevBlockNumber = h.blockNumber
-	block := h.getBlock(0)
+	block := h.getBlock(ctx, 0)
 	if block == nil {
 		return
 	}
@@ -213,11 +245,11 @@ func (h *HeimdallProvider) refreshBlockBuffer() {
 
 	h.logger.Debug().Uint64("block_number", h.blockNumber).Msg("Refreshing Heimdall state")
 	if h.prevBlockNumber != 0 && h.prevBlockNumber != h.blockNumber {
-		h.fillRange(h.prevBlockNumber)
+		h.fillRange(ctx, h.prevBlockNumber)
 	}
 }
 
-func (h *HeimdallProvider) getBlock(height uint64) *observer.HeimdallBlock {
+func (h *HeimdallProvider) getBlock(ctx context.Context, height uint64) *observer.HeimdallBlock {
 	path, err := url.JoinPath(h.tendermintURL, "block")
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to join path when fetching Heimdall block")
@@ -229,7 +261,7 @@ func (h *HeimdallProvider) getBlock(height uint64) *observer.HeimdallBlock {
 	}
 
 	var block observer.HeimdallBlock
-	err = api.GetJSON(path, &block)
+	err = api.GetJSON(ctx, path, &block)
 	if err != nil {
 		h.logger.Warn().Err(err).Msg("Failed to get Heimdall block")
 		return nil
@@ -238,7 +270,7 @@ func (h *HeimdallProvider) getBlock(height uint64) *observer.HeimdallBlock {
 	return &block
 }
 
-func (h *HeimdallProvider) getValidators(height uint64) *observer.HeimdallValidators {
+func (h *HeimdallProvider) getValidators(ctx context.Context, height uint64) *observer.HeimdallValidators {
 	path, err := url.JoinPath(h.tendermintURL, "validators")
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to join path when fetching Heimdall validators")
@@ -250,7 +282,7 @@ func (h *HeimdallProvider) getValidators(height uint64) *observer.HeimdallValida
 	}
 
 	var validators observer.HeimdallValidators
-	err = api.GetJSON(path, &validators)
+	err = api.GetJSON(ctx, path, &validators)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall validators")
 		return nil
@@ -260,7 +292,7 @@ func (h *HeimdallProvider) getValidators(height uint64) *observer.HeimdallValida
 }
 
 // getValidatorsAtHeight fetches all validators at a specific height with pagination.
-func (h *HeimdallProvider) getValidatorsAtHeight(height uint64) ([]*observer.HeimdallValidator, error) {
+func (h *HeimdallProvider) getValidatorsAtHeight(ctx context.Context, height uint64) ([]*observer.HeimdallValidator, error) {
 	const perPage = 100
 	const maxPages = 10
 
@@ -275,7 +307,7 @@ func (h *HeimdallProvider) getValidatorsAtHeight(height uint64) ([]*observer.Hei
 		path = fmt.Sprintf("%s?height=%d&per_page=%d&page=%d", path, height, perPage, page)
 
 		var validators observer.HeimdallValidators
-		if err := api.GetJSON(path, &validators); err != nil {
+		if err := api.GetJSON(ctx, path, &validators); err != nil {
 			return nil, fmt.Errorf("failed to get validators at height %d page %d: %w", height, page, err)
 		}
 
@@ -290,14 +322,14 @@ func (h *HeimdallProvider) getValidatorsAtHeight(height uint64) ([]*observer.Hei
 	return v, nil
 }
 
-func (h *HeimdallProvider) fillRange(start uint64) {
+func (h *HeimdallProvider) fillRange(ctx context.Context, start uint64) {
 	h.logger.Debug().
 		Uint64("start_block", start).
 		Uint64("end_block", h.blockNumber).
 		Msg("Filling block range")
 
 	for i := start; i <= h.blockNumber; i++ {
-		block := h.getBlock(i)
+		block := h.getBlock(ctx, i)
 		if block == nil {
 			h.logger.Warn().Uint64("block_number", i).Msg("Failed to get block")
 			break
@@ -307,30 +339,64 @@ func (h *HeimdallProvider) fillRange(start uint64) {
 	}
 }
 
-func (h *HeimdallProvider) refreshMilestone() error {
-	path, err := url.JoinPath(h.heimdallURL, "milestones", "count")
-	if err != nil {
-		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone count path")
-		return err
-	}
+// maxMilestonesPerPoll bounds how many milestones the per-milestone (count/vote)
+// stream drains in a single cycle. Freshness is handled separately via the tip
+// milestone, so this only bounds backlog accounting work; older milestones are
+// dropped (and counted in milestone_skipped) rather than delaying the cycle.
+const maxMilestonesPerPoll = 50
 
-	var count observer.HeimdallMilestoneCount
-	if err := api.GetJSON(path, &count); err != nil {
-		h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone count")
-		return err
-	}
+// maxMilestonesForVoteScan is the backlog size at or below which per-milestone
+// vote-extension scans (findMilestoneVotes, up to ~11 requests each) run. When
+// further behind, vote/proposer accounting is skipped so the cycle keeps pace;
+// freshness is unaffected.
+const maxMilestonesForVoteScan = 3
 
-	currentCount := int64(count.Count)
+func (h *HeimdallProvider) refreshMilestone(ctx context.Context) error {
 	h.milestones = nil
+	h.skippedMilestones = 0
 
-	// On first poll, fetch only the latest milestone to establish baseline.
-	// On subsequent polls, fetch all new milestones in range.
+	// Always fetch the tip milestone first; it drives the freshness gauges
+	// regardless of how far behind the per-milestone backfill below is.
+	latest, currentCount, err := h.getLatestMilestone(ctx)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("Failed to get latest Heimdall milestone")
+		return err
+	}
+	h.latestMilestone = latest
+
+	if currentCount <= h.prevMilestoneCount {
+		h.prevMilestoneCount = currentCount
+		return nil
+	}
+
+	// On first poll, baseline to the tip; otherwise backfill new milestones.
 	start := h.prevMilestoneCount + 1
 	if h.prevMilestoneCount == 0 {
 		start = currentCount
 	}
 
+	// Bound the catch-up so a large backlog can't turn into thousands of
+	// sequential fetches. The newest milestones are always kept.
+	if currentCount-start+1 > maxMilestonesPerPoll {
+		h.skippedMilestones = currentCount - start + 1 - maxMilestonesPerPoll
+		h.logger.Warn().
+			Int64("skipped", h.skippedMilestones).
+			Int64("from", start).
+			Int64("to", currentCount).
+			Msg("Milestone backlog exceeds cap; skipping older milestones")
+		start = currentCount - maxMilestonesPerPoll + 1
+	}
+
+	// Only pay the per-milestone vote-extension scan cost when nearly caught up.
+	scanVotes := h.validatorIDMap != nil && currentCount-start+1 <= maxMilestonesForVoteScan
+	voteCache := make(map[uint64]*voteEntry)
+
 	for i := start; i <= currentCount; i++ {
+		if ctx.Err() != nil {
+			h.logger.Warn().Err(ctx.Err()).Int64("milestone", i).Msg("Milestone refresh deadline reached; stopping catch-up")
+			break
+		}
+
 		path, err := url.JoinPath(h.heimdallURL, "milestones", strconv.FormatInt(i, 10))
 		if err != nil {
 			h.logger.Error().Err(err).Msg("Failed to get Heimdall milestone path")
@@ -338,7 +404,7 @@ func (h *HeimdallProvider) refreshMilestone() error {
 		}
 
 		var v2 observer.HeimdallMilestoneV2
-		if err = api.GetJSON(path, &v2); err != nil {
+		if err = api.GetJSON(ctx, path, &v2); err != nil {
 			h.logger.Error().Err(err).Int64("milestone", i).Msg("Failed to get Heimdall milestone")
 			continue
 		}
@@ -346,8 +412,9 @@ func (h *HeimdallProvider) refreshMilestone() error {
 		milestone := &v2.Milestone
 		milestone.Count = i
 
-		// Find and attach votes for this milestone
-		milestone.Votes = h.findMilestoneVotes(milestone)
+		if scanVotes {
+			milestone.Votes = h.findMilestoneVotes(ctx, milestone, voteCache)
+		}
 
 		h.milestones = append(h.milestones, milestone)
 	}
@@ -356,7 +423,38 @@ func (h *HeimdallProvider) refreshMilestone() error {
 	return nil
 }
 
-func (h *HeimdallProvider) refreshCheckpoint() error {
+// getLatestMilestone fetches the current tip milestone along with the total
+// milestone count. The milestone's Count is set to the total so downstream
+// freshness gauges report the tip index.
+func (h *HeimdallProvider) getLatestMilestone(ctx context.Context) (*observer.HeimdallMilestone, int64, error) {
+	countPath, err := url.JoinPath(h.heimdallURL, "milestones", "count")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var count observer.HeimdallMilestoneCount
+	if err := api.GetJSON(ctx, countPath, &count); err != nil {
+		return nil, 0, err
+	}
+	currentCount := int64(count.Count)
+
+	latestPath, err := url.JoinPath(h.heimdallURL, "milestones", "latest")
+	if err != nil {
+		return nil, currentCount, err
+	}
+
+	var v2 observer.HeimdallMilestoneV2
+	if err := api.GetJSON(ctx, latestPath, &v2); err != nil {
+		return nil, currentCount, err
+	}
+
+	milestone := &v2.Milestone
+	milestone.Count = currentCount
+
+	return milestone, currentCount, nil
+}
+
+func (h *HeimdallProvider) refreshCheckpoint(ctx context.Context) error {
 	path, err := url.JoinPath(h.heimdallURL, "checkpoints", "latest")
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall latest checkpoint path")
@@ -364,7 +462,7 @@ func (h *HeimdallProvider) refreshCheckpoint() error {
 	}
 
 	var v2 observer.HeimdallCheckpointV2
-	if err = api.GetJSON(path, &v2); err != nil {
+	if err = api.GetJSON(ctx, path, &v2); err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall latest checkpoint")
 		return err
 	}
@@ -374,7 +472,7 @@ func (h *HeimdallProvider) refreshCheckpoint() error {
 	return nil
 }
 
-func (h *HeimdallProvider) refreshBufferedCheckpoint() error {
+func (h *HeimdallProvider) refreshBufferedCheckpoint(ctx context.Context) error {
 	path, err := url.JoinPath(h.heimdallURL, "checkpoints", "buffer")
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall buffered checkpoint path")
@@ -382,7 +480,7 @@ func (h *HeimdallProvider) refreshBufferedCheckpoint() error {
 	}
 
 	var v2 observer.HeimdallCheckpointV2
-	if err = api.GetJSON(path, &v2); err != nil {
+	if err = api.GetJSON(ctx, path, &v2); err != nil {
 		h.logger.Warn().Err(err).Msg("Failed to get Heimdall buffered checkpoint")
 		h.bufferedCheckpoint = nil
 		return err
@@ -398,21 +496,21 @@ func (h *HeimdallProvider) refreshBufferedCheckpoint() error {
 	return nil
 }
 
-func (h *HeimdallProvider) getCurrentCheckpointProposer() (string, error) {
+func (h *HeimdallProvider) getCurrentCheckpointProposer(ctx context.Context) (string, error) {
 	path, err := url.JoinPath(h.heimdallURL, "checkpoints", "prepare-next")
 	if err != nil {
 		return "", err
 	}
 
 	var resp observer.HeimdallPrepareNextCheckpoint
-	if err = api.GetJSON(path, &resp); err != nil {
+	if err = api.GetJSON(ctx, path, &resp); err != nil {
 		return "", err
 	}
 
 	return resp.Checkpoint.Proposer, nil
 }
 
-func (h *HeimdallProvider) refreshMissedCheckpointProposal() error {
+func (h *HeimdallProvider) refreshMissedCheckpointProposal(ctx context.Context) error {
 	var proposers []string
 	for pair := h.checkpointProposers.Oldest(); pair != nil; pair = pair.Next() {
 		proposers = append(proposers, pair.Key)
@@ -425,7 +523,7 @@ func (h *HeimdallProvider) refreshMissedCheckpointProposal() error {
 
 	h.missedCheckpointProposers = nil
 
-	signer, err := h.getCurrentCheckpointProposer()
+	signer, err := h.getCurrentCheckpointProposer(ctx)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall current checkpoint proposer")
 		return err
@@ -454,17 +552,17 @@ func (h *HeimdallProvider) refreshMissedCheckpointProposal() error {
 	return nil
 }
 
-func (h *HeimdallProvider) refreshMissedBlockProposal() error {
+func (h *HeimdallProvider) refreshMissedBlockProposal(ctx context.Context) error {
 	missedBlockProposal := make(observer.HeimdallMissedBlockProposal)
 	for i := h.prevBlockNumber + 1; i <= h.blockNumber && h.prevBlockNumber != 0; i++ {
-		block := h.getBlock(i)
+		block := h.getBlock(ctx, i)
 		if block == nil {
 			h.logger.Debug().Msg("Failed to get current block")
 			continue
 		}
 		proposer := block.ProposerAddress()
 
-		v := h.getValidators(i - 1)
+		v := h.getValidators(ctx, i-1)
 		if v == nil {
 			h.logger.Debug().Msg("Failed to get validators")
 			continue
@@ -494,9 +592,9 @@ func (h *HeimdallProvider) refreshMissedBlockProposal() error {
 	return nil
 }
 
-func (h *HeimdallProvider) refreshSpan() error {
+func (h *HeimdallProvider) refreshSpan(ctx context.Context) error {
 	// Always fetch the latest span
-	latest, err := h.getLatestSpan()
+	latest, err := h.getLatestSpan(ctx)
 	if err != nil {
 		return err
 	}
@@ -529,7 +627,7 @@ func (h *HeimdallProvider) refreshSpan() error {
 
 	// Fetch next span sequentially to ensure overlap detection works
 	next := h.spans.Curr.ID + 1
-	span, err := h.getSpan(next)
+	span, err := h.getSpan(ctx, next)
 	if err != nil {
 		h.logger.Warn().Uint64("span_id", next).Err(err).Msg("Failed to fetch span")
 		return err
@@ -540,15 +638,15 @@ func (h *HeimdallProvider) refreshSpan() error {
 	return nil
 }
 
-func (h *HeimdallProvider) getLatestSpan() (*observer.HeimdallSpan, error) {
-	return h.fetchSpan("latest")
+func (h *HeimdallProvider) getLatestSpan(ctx context.Context) (*observer.HeimdallSpan, error) {
+	return h.fetchSpan(ctx, "latest")
 }
 
-func (h *HeimdallProvider) getSpan(id uint64) (*observer.HeimdallSpan, error) {
-	return h.fetchSpan(strconv.FormatUint(id, 10))
+func (h *HeimdallProvider) getSpan(ctx context.Context, id uint64) (*observer.HeimdallSpan, error) {
+	return h.fetchSpan(ctx, strconv.FormatUint(id, 10))
 }
 
-func (h *HeimdallProvider) fetchSpan(spanID string) (*observer.HeimdallSpan, error) {
+func (h *HeimdallProvider) fetchSpan(ctx context.Context, spanID string) (*observer.HeimdallSpan, error) {
 	path, err := url.JoinPath(h.heimdallURL, "bor", "spans", spanID)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall span path")
@@ -556,7 +654,7 @@ func (h *HeimdallProvider) fetchSpan(spanID string) (*observer.HeimdallSpan, err
 	}
 
 	var v2 observer.HeimdallSpanV2
-	if err = api.GetJSON(path, &v2); err != nil {
+	if err = api.GetJSON(ctx, path, &v2); err != nil {
 		h.logger.Error().Err(err).Msg("Failed to get Heimdall span")
 		return nil, err
 	}
@@ -595,14 +693,14 @@ func (h *HeimdallProvider) refreshValidatorSet() error {
 	return nil
 }
 
-func (h *HeimdallProvider) getCommit(height uint64) (*observer.HeimdallCommit, error) {
+func (h *HeimdallProvider) getCommit(ctx context.Context, height uint64) (*observer.HeimdallCommit, error) {
 	path, err := url.JoinPath(h.tendermintURL, "commit")
 	if err != nil {
 		return nil, fmt.Errorf("failed to join commit path: %w", err)
 	}
 
 	var commit observer.HeimdallCommit
-	if err := api.GetJSON(fmt.Sprintf("%s?height=%d", path, height), &commit); err != nil {
+	if err := api.GetJSON(ctx, fmt.Sprintf("%s?height=%d", path, height), &commit); err != nil {
 		return nil, fmt.Errorf("failed to get commit at height %d: %w", height, err)
 	}
 
@@ -613,13 +711,13 @@ func normalizeAddress(addr string) string {
 	return strings.ToLower(strings.TrimPrefix(addr, "0x"))
 }
 
-func (h *HeimdallProvider) getMissedVotes(height uint64) (*observer.HeimdallMissedVotes, error) {
-	validators, err := h.getValidatorsAtHeight(height)
+func (h *HeimdallProvider) getMissedVotes(ctx context.Context, height uint64) (*observer.HeimdallMissedVotes, error) {
+	validators, err := h.getValidatorsAtHeight(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validators at height %d: %w", height, err)
 	}
 
-	commit, err := h.getCommit(height)
+	commit, err := h.getCommit(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -662,7 +760,7 @@ func (h *HeimdallProvider) getMissedVotes(height uint64) (*observer.HeimdallMiss
 	}, nil
 }
 
-func (h *HeimdallProvider) refreshMissedVotes() {
+func (h *HeimdallProvider) refreshMissedVotes(ctx context.Context) {
 	if h.validatorIDMap == nil {
 		return
 	}
@@ -672,7 +770,7 @@ func (h *HeimdallProvider) refreshMissedVotes() {
 	h.logger.Debug().Msg("Refreshing missed consensus votes")
 
 	for height := h.prevBlockNumber + 1; height <= h.blockNumber && h.prevBlockNumber != 0; height++ {
-		mv, err := h.getMissedVotes(height)
+		mv, err := h.getMissedVotes(ctx, height)
 		if err != nil {
 			h.logger.Warn().Err(err).Uint64("height", height).Msg("Failed to detect missed votes")
 			continue
@@ -685,8 +783,8 @@ func (h *HeimdallProvider) refreshMissedVotes() {
 
 // getExtendedCommitInfo fetches and decodes the ExtendedCommitInfo from txs[0]
 // of a Heimdall block. Vote extensions from block H-1 are stored in block H's txs[0].
-func (h *HeimdallProvider) getExtendedCommitInfo(height uint64) (*heimdall.ExtendedCommitInfo, error) {
-	block := h.getBlock(height)
+func (h *HeimdallProvider) getExtendedCommitInfo(ctx context.Context, height uint64) (*heimdall.ExtendedCommitInfo, error) {
+	block := h.getBlock(ctx, height)
 	if block == nil {
 		return nil, fmt.Errorf("failed to get block at height %d", height)
 	}
@@ -711,8 +809,8 @@ func (h *HeimdallProvider) getExtendedCommitInfo(height uint64) (*heimdall.Exten
 }
 
 // getMilestoneVotes processes vote extensions from a block and returns milestone vote data.
-func (h *HeimdallProvider) getMilestoneVotes(height uint64) (*observer.HeimdallMilestoneVotes, error) {
-	extCommit, err := h.getExtendedCommitInfo(height)
+func (h *HeimdallProvider) getMilestoneVotes(ctx context.Context, height uint64) (*observer.HeimdallMilestoneVotes, error) {
+	extCommit, err := h.getExtendedCommitInfo(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -786,12 +884,12 @@ func (h *HeimdallProvider) getMilestoneFromVoteExtension(vote *observer.Heimdall
 
 // getBlockHeight estimates the Heimdall block height for a given timestamp.
 // Assumes ~2 second block time.
-func (h *HeimdallProvider) getBlockHeight(target int64) uint64 {
+func (h *HeimdallProvider) getBlockHeight(ctx context.Context, target int64) uint64 {
 	if h.blockNumber == 0 {
 		return 0
 	}
 
-	block := h.getBlock(0)
+	block := h.getBlock(ctx, 0)
 	if block == nil {
 		return 0
 	}
@@ -814,15 +912,24 @@ func (h *HeimdallProvider) getBlockHeight(target int64) uint64 {
 	return h.blockNumber - uint64(diff)
 }
 
+// voteEntry memoizes a getMilestoneVotes result (including errors) for a height
+// within a single refresh cycle. Adjacent milestones scan overlapping windows,
+// so caching avoids refetching the same blocks and vote extensions.
+type voteEntry struct {
+	votes *observer.HeimdallMilestoneVotes
+	err   error
+}
+
 // findMilestoneVotes searches for votes matching this milestone's range.
 // Uses the milestone timestamp to estimate the finalization block.
-// Returns the first matching vote block, or nil if not found.
-func (h *HeimdallProvider) findMilestoneVotes(milestone *observer.HeimdallMilestone) *observer.HeimdallMilestoneVotes {
+// Returns the first matching vote block, or nil if not found. The cache
+// memoizes per-height lookups across milestones within the same cycle.
+func (h *HeimdallProvider) findMilestoneVotes(ctx context.Context, milestone *observer.HeimdallMilestone, cache map[uint64]*voteEntry) *observer.HeimdallMilestoneVotes {
 	if h.validatorIDMap == nil {
 		return nil
 	}
 
-	height := h.getBlockHeight(milestone.Timestamp)
+	height := h.getBlockHeight(ctx, milestone.Timestamp)
 	if height == 0 {
 		return nil
 	}
@@ -833,11 +940,17 @@ func (h *HeimdallProvider) findMilestoneVotes(milestone *observer.HeimdallMilest
 	end := min(h.blockNumber, height+window)
 
 	for i := start; i <= end; i++ {
-		mv, err := h.getMilestoneVotes(i)
-		if err != nil {
+		entry, ok := cache[i]
+		if !ok {
+			votes, err := h.getMilestoneVotes(ctx, i)
+			entry = &voteEntry{votes: votes, err: err}
+			cache[i] = entry
+		}
+		if entry.err != nil {
 			continue
 		}
 
+		mv := entry.votes
 		if mv.MilestoneVoters == 0 {
 			continue
 		}

--- a/provider/heimdall_test.go
+++ b/provider/heimdall_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -62,7 +63,7 @@ func TestRefreshSpan_Bootstrap(t *testing.T) {
 
 	h := newProvider(server.URL, nil)
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -87,7 +88,7 @@ func TestRefreshSpan_Sequential(t *testing.T) {
 
 	h := newProvider(server.URL, newSpan(100, 1000, 1099))
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -115,7 +116,7 @@ func TestRefreshSpan_NextSpanNotAvailable(t *testing.T) {
 	h := newProvider(server.URL, newSpan(100, 1000, 1099))
 	originalCurr := h.spans.Curr
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -138,7 +139,7 @@ func TestRefreshSpan_DetectsOverlappingSpans(t *testing.T) {
 
 	h := newProvider(server.URL, newSpan(100, 1000, 1099))
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -166,7 +167,7 @@ func TestRefreshSpan_GapFillsOneAtATime(t *testing.T) {
 	h := newProvider(server.URL, newSpan(100, 1000, 1099))
 
 	// First call: should advance from 100 to 101 only
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 	if h.spans.Curr.ID != 101 {
@@ -177,7 +178,7 @@ func TestRefreshSpan_GapFillsOneAtATime(t *testing.T) {
 	}
 
 	// Second call: should advance from 101 to 102
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 	if h.spans.Curr.ID != 102 {
@@ -188,7 +189,7 @@ func TestRefreshSpan_GapFillsOneAtATime(t *testing.T) {
 	}
 
 	// Third call: should advance from 102 to 103
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 	if h.spans.Curr.ID != 103 {
@@ -200,7 +201,7 @@ func TestRefreshSpan_GapFillsOneAtATime(t *testing.T) {
 
 	// Fourth call: should not advance (already at latest)
 	prevCurr := h.spans.Curr
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 	if h.spans.Curr != prevCurr {
@@ -218,7 +219,7 @@ func TestFetchSpan_RejectsZeroValueSpan(t *testing.T) {
 	defer server.Close()
 
 	h := newProvider(server.URL, nil)
-	_, err := h.fetchSpan("latest")
+	_, err := h.fetchSpan(context.Background(), "latest")
 
 	if err == nil {
 		t.Fatal("expected error for zero-value span, got nil")
@@ -238,7 +239,7 @@ func TestFetchSpan_AcceptsValidSpanZero(t *testing.T) {
 	defer server.Close()
 
 	h := newProvider(server.URL, nil)
-	span, err := h.fetchSpan("0")
+	span, err := h.fetchSpan(context.Background(), "0")
 
 	if err != nil {
 		t.Fatalf("expected no error for valid span 0, got: %v", err)
@@ -263,7 +264,7 @@ func TestRefreshSpan_ExcessiveLagJumpsToLatest(t *testing.T) {
 	// With maxSpanLag = 5, should jump to latest
 	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 5)
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -287,7 +288,7 @@ func TestRefreshSpan_WithinLagWalksSequentially(t *testing.T) {
 	// With maxSpanLag = 10, should walk sequentially
 	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 10)
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 
@@ -312,7 +313,7 @@ func TestRefreshSpan_ExactLagThresholdWalksSequentially(t *testing.T) {
 	// With maxSpanLag = 10, should walk sequentially (lag is not > maxSpanLag)
 	h := newProviderWithMaxLag(server.URL, newSpan(100, 10000, 10099), 10)
 
-	if err := h.refreshSpan(); err != nil {
+	if err := h.refreshSpan(context.Background()); err != nil {
 		t.Fatalf("refreshSpan() error: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

`panoptichain_heimdall_time_since_last_milestone` stalls on Polygon PoS. Observed in prod (Datadog):
Amoy frozen ~11 min behind, mainnet ~3–5 min behind, with the observed milestone count trailing
upstream by ~600 and never catching up — while the Heimdall v2 nodes themselves are healthy and
serving fresh milestones.

## Root cause

`refreshMilestone` drains the **entire** `prevCount+1..currentCount` range serially every cycle, and
each milestone triggers `findMilestoneVotes`, which scans a ±5 block window = up to ~11 extra
`GET`s (block + vote-extension decode) per milestone. Under Heimdall v2 the milestone count is in the
millions and increments ~1–2/s, so a single cycle can take minutes. Because the freshness gauge is
only set inside `MilestoneObserver.Notify` from the *published backlog* milestones (and
`PublishEvents` runs only after `RefreshState` finishes), the gauge effectively reports **cycle
latency**, not true milestone age. Nothing bounded a cycle: the context was `context.Background()` and
`api.GetJSON` ignored it.

## Changes

- **Decouple freshness from the backlog.** Fetch `/milestones/latest` once per cycle and publish it on
  a new `MilestoneLatest` topic that drives the `time`/`count`/`start_block`/`end_block` gauges. The
  per-milestone stream keeps `observed`/`proposed`/`block_range`/vote metrics. Freshness can no longer
  lag behind a slow catch-up.
- **Bound catch-up** to `maxMilestonesPerPoll` (50); always keep the newest, and count dropped
  milestones in a new **`milestone_skipped`** counter (logged too, so drops are visible).
- **Skip the vote-extension scan when behind** (`maxMilestonesForVoteScan` = 3). Vote/proposer
  accounting gaps during bursts — acceptable and now observable — while freshness stays correct.
- **Per-height vote cache** within a cycle so adjacent milestones' overlapping ±5 windows don't
  refetch the same blocks/vote extensions.
- **Bound each cycle**: `RefreshState` wraps the context with a deadline (`refreshTimeout`, derived
  from the polling interval), and `api.GetJSON` is now context-aware (`http.NewRequestWithContext`)
  backed by a single **pooled** `http.Client` (was a fresh client per call). Freshness is captured
  before the bounded work, so a truncated cycle never affects it.

This is context-threaded through the Heimdall provider helpers; `api.GetJSON`'s signature change also
touches `exchange_rates.go`, `grafana.go` (now shares the pooled client for its POST), and the `api`
tests. The `api/validator.go` path uses a documented `context.Background()` seam (cached 1h) pending a
follow-up.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Generated files updated (`make -B metrics.md && go generate ./...`) — adds `milestone_skipped`
- [ ] Deploy to staging/prod and confirm `time_since_last_milestone` returns to ~seconds on both
      `polygon_mainnet` and `polygon_amoy`, `milestone_end_block`/`milestone_count` track the tip, and
      `milestone_skipped` only increments during a genuine backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)